### PR TITLE
Port Variable last update and add SWP Matchmaking routes

### DIFF
--- a/hdp_api/_router.py
+++ b/hdp_api/_router.py
@@ -26,6 +26,7 @@ from hypercube_api.hdp_api.routes.rules import Rules
 from hypercube_api.hdp_api.routes.rulesetViz import RulesetViz
 from hypercube_api.hdp_api.routes.schedulerDashboard import SchedulerDashboard
 from hypercube_api.hdp_api.routes.simpleLift import SimpleLift
+from hypercube_api.hdp_api.routes.swpMatchmaking import SWPMatchmaking
 from hypercube_api.hdp_api.routes.system import System
 from hypercube_api.hdp_api.routes.tags import Tags
 from hypercube_api.hdp_api.routes.task import Task
@@ -73,6 +74,7 @@ class Router(object):
         RulesetViz,
         SchedulerDashboard,
         SimpleLift,
+        SWPMatchmaking,
         System,
         Tags,
         Task,

--- a/hdp_api/routes/swpMatchmaking.py
+++ b/hdp_api/routes/swpMatchmaking.py
@@ -1,0 +1,24 @@
+from hypercube_api.hdp_api.routes import Resource, Route
+
+
+class SWPMatchmaking(Resource):
+    name = "swpMatchmaking"
+
+    class _getAgents(Route):
+        name = "getAgents"
+        httpMethod = Route.GET
+        path = "/projects/{project_ID}/redeployments/{work_ID}/agents"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'work_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _getMatches(Route):
+        name = "getMatches"
+        httpMethod = Route.GET
+        path = "/projects/{project_ID}/redeployments/{work_ID}/agents/{agent_ID}"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'work_ID': Route.VALIDATOR_OBJECTID,
+            'agent_ID': Route.VALIDATOR_ANY,
+        }

--- a/hyper_api/variable.py
+++ b/hyper_api/variable.py
@@ -169,6 +169,10 @@ class DiscreteVariable(Variable):
         return self.__json_returned['stats']['distribution']['X']
 
     @property
+    def modality_count(self):
+        return self.__json_returned['stats']['modalitiesCount']
+
+    @property
     def frequencies(self):
         return self.__json_returned['stats']['distribution']['Y']
 


### PR DESCRIPTION
#### Adding Matchmaking routes for the SWP project : 
- `GET /projects/{project_ID}/redeployments/{work_ID}/agents` : listing unmatched agents available for redeployment.
- `/projects/{project_ID}/redeployments/{work_ID}/agents/{agent_ID}` : listing all possible redeployments for a given agent.

#### Incorporating last update on hyper_api to return modality count for Variables.