### PR TITLE
Delete aggregation route on alerts

### DIFF
--- a/hdp_api/routes/alerts.py
+++ b/hdp_api/routes/alerts.py
@@ -12,16 +12,7 @@ class Alerts(Resource):
             'project_ID': Route.VALIDATOR_OBJECTID,
             'dataset_ID': Route.VALIDATOR_OBJECTID,
         }
-
-    class _getAlertsAggregate(Route):
-        name = "getAlertsAggregate"
-        httpMethod = Route.GET
-        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/aggregate"
-        _path_keys = {
-            'project_ID': Route.VALIDATOR_OBJECTID,
-            'dataset_ID': Route.VALIDATOR_OBJECTID,
-        }
-
+        
     class _getAlert(Route):
         name = "getAlert"
         httpMethod = Route.GET


### PR DESCRIPTION
Deletion of the aggregation route (_getAlertsAggregate) that used to get the list of alerts on a dataset, to use an other existing route (_getAlerts).

It was made to simplify the code and be able to use only one path (prevents complications and bugs)