### PR TITLE
Update Alerts and Reshapes routes with missing changes

### DIFF
--- a/hdp_api/routes/alerts.py
+++ b/hdp_api/routes/alerts.py
@@ -6,13 +6,53 @@ class Alerts(Resource):
 
     class _getAlerts(Route):
         name = "getAlerts"
-        httpMethod = Route.GET
-        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts"
+        httpMethod = Route.POST
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'dataset_ID': Route.VALIDATOR_OBJECTID,
         }
-        
+
+    class _computeAlerts(Route):
+        name = "computeAlerts"
+        httpMethod = Route.POST
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group/{alert_group_ID}/compute"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'alert_group_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _ignoreAlerts(Route):
+        name = "ignoreAlerts"
+        httpMethod = Route.POST
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group/{alert_group_ID}/ignore"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'alert_group_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _resolveAlerts(Route):
+        name = "resolveAlerts"
+        httpMethod = Route.POST
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group/{alert_group_ID}/resolve"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'alert_group_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _proposeAlertsResolution(Route):
+        name = "proposeAlertsResolution"
+        httpMethod = Route.POST
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group/{alert_group_ID}/proposeResolution"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'alert_group_ID': Route.VALIDATOR_OBJECTID,
+        }
+
     class _getAlert(Route):
         name = "getAlert"
         httpMethod = Route.GET
@@ -23,20 +63,30 @@ class Alerts(Resource):
             'alert_ID': Route.VALIDATOR_OBJECTID,
         }
 
-    class _updateAlert(Route):
-        name = "updateAlert"
+    class _ignoreAlert(Route):
+        name = "ignoreAlert"
         httpMethod = Route.POST
-        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}/ignore"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'dataset_ID': Route.VALIDATOR_OBJECTID,
             'alert_ID': Route.VALIDATOR_OBJECTID,
         }
 
-    class _computeAlert(Route):
-        name = "computeAlert"
+    class _resolveAlert(Route):
+        name = "resolveAlert"
         httpMethod = Route.POST
-        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}/compute"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}/resolve"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'alert_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _proposeAlertResolution(Route):
+        name = "proposeAlertResolution"
+        httpMethod = Route.GET
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}/proposeResolution"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'dataset_ID': Route.VALIDATOR_OBJECTID,

--- a/hdp_api/routes/datasetReshapes.py
+++ b/hdp_api/routes/datasetReshapes.py
@@ -144,3 +144,12 @@ class DatasetReshapes(Resource):
             'project_ID': Route.VALIDATOR_OBJECTID,
             'dataset_ID': Route.VALIDATOR_OBJECTID,
         }
+
+    class _proposeAlterations(Route):
+        name = "proposeAlterations"
+        httpMethod = Route.POST
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/reshapes/proposeAlterations"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+        }


### PR DESCRIPTION
Alerts and reshapes routes have been updated but the corresponding code wasn't ported. 

#### Alerts
- getAlerts (updated) : get all alerts from a group
- computeAlert (removed) : compute a specific alert
- computeAlerts (new) : compute all alerts from a group
- ignoreAlert (new) : ignore a specific alert
- ignoreAlerts (new) : ignore all alerts from a group
- resolveAlert (new) : resolve a specific alert
- proposeAlertResolution (new) : get a proposed transformation based on an alert
- proposeAlertsResolution (new) : get proposed transformation for all alerts from a group
- updateAlert (removed) : update an alert

#### Reshapes
- proposeAlterations (new) : get a list of empty transformation (update) on a provided list of variables