### PR TITLE
Add route to access Dataset-level resources

### DIFF
--- a/hdp_api/_router.py
+++ b/hdp_api/_router.py
@@ -8,6 +8,7 @@ from HyperAPI.hdp_api.routes.correlations import Correlations
 from HyperAPI.hdp_api.routes.dashboards import Dashboards
 from HyperAPI.hdp_api.routes.datasets import Datasets
 from HyperAPI.hdp_api.routes.datasetReshapes import DatasetReshapes
+from HyperAPI.hdp_api.routes.datasetResources import DatasetResources
 from HyperAPI.hdp_api.routes.docapi import DocApi
 from HyperAPI.hdp_api.routes.exports import Exports
 from HyperAPI.hdp_api.routes.hyperEngines import HyperEngines
@@ -55,6 +56,7 @@ class Router(object):
         Dashboards,
         Datasets,
         DatasetReshapes,
+        DatasetResources,
         DocApi,
         Exports,
         HyperEngines,

--- a/hdp_api/routes/datasetResources.py
+++ b/hdp_api/routes/datasetResources.py
@@ -1,0 +1,14 @@
+from HyperAPI.hdp_api.routes import Resource, Route
+
+
+class DatasetResources(Resource):
+    name = "DatasetResources"
+
+    class _getDatasetResource(Route):
+        name = "getDatasetResource"
+        httpMethod = Route.GET
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/resources"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+        }


### PR DESCRIPTION
#### New route :
`/projects/{project_ID}/datasets/{dataset_ID}/resources?{handler}={resource_ID}`
This route allows the user to fetch resources that may be generated at a dataset level. 

#### Usage : 
```
params = {"handler": "resource_ID"}
api.DatasetResources.getdatasetresource(project_ID="project_ID", dataset_ID="dataset_ID", params=params)
```

#### Returns : 

- 200 Success : Content of the resource
- 403 Not Authorized : Not logged or feature not available for the user
- 500 Error : Unable to access the resource

For security purposes, no details are given on whether the requested project, dataset, resource exists or not. 