### PR TITLE
Change the route to export the tunes of a particular forecast

### DIFF
--- a/hdp_api/routes/nitro.py
+++ b/hdp_api/routes/nitro.py
@@ -94,7 +94,7 @@ class Nitro(Resource):
 
     class _exportForecastTunes(Route):
         name = "exportForecastTunes"
-        httpMethod = Route.POST
+        httpMethod = Route.GET
         path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/export"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,


### PR DESCRIPTION
#### Changed route :
`/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/export`
This route allows the user to get a link to export Tunes from a Forecast.

#### Usage : 
```
api.DatasetResources.exportforcasttunes/(project_ID="project_ID", dataset_ID="dataset_ID", forecast_ID="forecast_ID")
```

#### Returns : 
- 200 Success : Return in the body, a json containing the url to download the Forecast Tunes file
- 403 Not Authorized : Not logged or feature not available for the user
- 500 Error : Unable to access the forecast tunes

For security purposes, no details are given on whether the requested project, dataset, forecast exists or not. 