### PR TITLE
Fix and Update version management

### DIFF
--- a/hdp_api/_router.py
+++ b/hdp_api/_router.py
@@ -101,9 +101,12 @@ class Router(object):
     def __init__(self, username=None, password=None, url=None, token=None, watcher=None):
         # Initiate session with HyperCube server
         self.session = Session(username=username, password=password, token=token, url=url)
-        # We must fetch the System version BEFORE creating route, so this call is hard coded
-        _system_details = self.session.request('GET', '/system/about')
-        _version = _system_details.get('version')
+        try:
+            # We must fetch the System version BEFORE creating route, so this call is hard coded
+            _system_details = self.session.request('GET', System._About.path)
+            _version = _system_details.get('version')
+        except Exception:
+            _version = Version('unknown')
         self.session.version = Version(_version)
 
         # Creating Resources

--- a/hdp_api/routes/base/resource_base.py
+++ b/hdp_api/routes/base/resource_base.py
@@ -15,10 +15,11 @@ class Resource(object):
         self.session = session
         self._routes = {}
         for _route in (_m[1] for _m in inspect.getmembers(self.__class__) if inspect.isclass(_m[1]) and issubclass(_m[1], Route)):
-            _routeInstance = _route(session, watcher=watcher)
-            _routeName = _route.get_route_name()
-            self.__setattr__(_routeName, _routeInstance)
-            self._routes[_routeName] = _routeInstance
+            if _route.available_since is None or _route.available_since >= self.session.version:
+                _routeInstance = _route(session, watcher=watcher)
+                _routeName = _route.get_route_name()
+                self.__setattr__(_routeName, _routeInstance)
+                self._routes[_routeName] = _routeInstance
 
     def __iter__(self):
         for _r in self._routes.values():

--- a/hdp_api/routes/base/route_base.py
+++ b/hdp_api/routes/base/route_base.py
@@ -16,6 +16,7 @@ class Route(object):
     VALIDATOR_INT = ValidatorInt()
 
     deprecated_since = None
+    available_since = None
 
     @classmethod
     def get_route_name(cls):

--- a/hdp_api/routes/base/version_management.py
+++ b/hdp_api/routes/base/version_management.py
@@ -2,7 +2,7 @@ from HyperAPI.utils.version import Version
 
 
 # Route version management --------------------------------------------------------------------------
-def deprecated(version: str):
+def deprecated_since(version: str):
     def cls_decorator(cls):
         cls.deprecated_since = Version(version)
         return cls
@@ -12,5 +12,12 @@ def deprecated(version: str):
 def reroute(version: str, reroute_to, convert_to: callable):
     def cls_decorator(cls):
         cls.add_redirection(Version(version), reroute_to, convert_to)
+        return cls
+    return cls_decorator
+
+
+def available_since(version: str):
+    def cls_decorator(cls):
+        cls.available_since = Version(version)
         return cls
     return cls_decorator

--- a/sessionClass.py
+++ b/sessionClass.py
@@ -99,7 +99,10 @@ class Session:
         params = params or {}
         json = json or {}
         data = data or {}
-        url = '{}{}'.format(self.api_entry_point, url)
+        if self.api_entry_point.endswith('/') and url.startswith('/'):
+            url = '{}{}'.format(self.api_entry_point, url[1:])
+        else:
+            url = '{}{}'.format(self.api_entry_point, url)
         method = method.upper()
         if method not in ['GET', 'POST']:
             raise ValueError("method should be in ['GET', 'POST']")
@@ -108,11 +111,7 @@ class Session:
             # Create new data with encoder
             encoder = MultipartEncoder(fields=data)
 
-            def callback(monitor):
-                msg = '{} bytes uploaded '.format(monitor.bytes_read)
-                print(msg, flush=True, end='\r')
-
-            multi_data = MultipartEncoderMonitor(encoder, callback)
+            multi_data = MultipartEncoderMonitor(encoder, None)
 
             headers = self.session.headers.copy()
             headers['Content-Type'] = multi_data.content_type


### PR DESCRIPTION
### Fixes: 
- The version management on the router startup wasn't compatible with current platforms due to a duplicate "/" on the `/about` route. The call has been secured so even a wrong call will not prevent the api from running and the session now checks for duplicate "/" before calls. 

### Updates: 
- The `deprecated` route decorator has been renamed `deprecated_since`. The decorator usage remains unchanged. 
- Added the `available_since` decorator. Which has a similar usage to the `deprecated_since` decorator.  If the server version is lower than the route version, the route is not created on the API. 

```
from HyperAPI.hdp_api.routes import Resource, Route, available_since
class System(Resource):
    name = "System"

    @available_since('4.3')
    class _Menu(Route):
        name = "Menu"
        httpMethod = Route.GET
        path = "/system/menu"
```

- The `X bytes uploaded` print has been removed from the session as it was limiting visibility on command line operations. 
