### PR TITLE
Update Version management to handle CI version

### DIFF
--- a/utils/version.py
+++ b/utils/version.py
@@ -4,8 +4,7 @@ import re
 class Version(object):
 
     def __init__(self, version_label: str):
-        pattern_version = re.compile('([0-9]*)\.([0-9]*)(-([0-9a-f]{40}))?', re.IGNORECASE)
-        result = pattern_version.search(version_label)
+        result = re.search('([\.0-9a-z]*)(-([0-9a-f]{40}))?', version_label, re.IGNORECASE)
         if result is None:
             self.major = None
             self.minor = None
@@ -13,10 +12,17 @@ class Version(object):
             self.is_dev = True
         else:
             _parts = result.groups()
-            self.major = int(_parts[0])
-            self.minor = int(_parts[1])
-            self.build = _parts[3]
-            self.is_dev = False
+            version_result = re.fullmatch('v?([0-9]*)\.([0-9]*)', _parts[0], re.IGNORECASE)
+            if version_result is not None:
+                _version_parts = version_result.groups()
+                self.major = int(_version_parts[0])
+                self.minor = int(_version_parts[1])
+                self.is_dev = False
+            else:
+                self.major = None
+                self.minor = None
+                self.is_dev = True
+            self.build = _parts[2]
 
     def __str__(self):
         if self.is_dev:


### PR DESCRIPTION
## Changes
Updating the version code to handle version labels with "v" prefixes or with a version name instead of major.minor syntax. 

#### Behaviour:
```
Version('4.3-b8da1dbae296964523bf0b86efa039c1679d9a7c').__dict__
{'build': 'b8da1dbae296964523bf0b86efa039c1679d9a7c',
 'is_dev': False,
 'major': 4,
 'minor': 3}
```

```
Version('v4.3-b8da1dbae296964523bf0b86efa039c1679d9a7c').__dict__
{'build': 'b8da1dbae296964523bf0b86efa039c1679d9a7c',
 'is_dev': False,
 'major': 4,
 'minor': 3}
```

```
Version('4.3v-b8da1dbae296964523bf0b86efa039c1679d9a7c').__dict__
{'build': 'b8da1dbae296964523bf0b86efa039c1679d9a7c',
 'is_dev': True,
 'major': None,
 'minor': None}
```

```
Version('master-b8da1dbae296964523bf0b86efa039c1679d9a7c').__dict__
{'build': 'b8da1dbae296964523bf0b86efa039c1679d9a7c',
 'is_dev': True,
 'major': None,
 'minor': None}
```

```
Version('dev').__dict__
{'build': None, 'is_dev': True, 'major': None, 'minor': None}
```