### PR TITLE
fixing smartDataViz route

### DIFF
--- a/hdp_api/routes/smartViz.py
+++ b/hdp_api/routes/smartViz.py
@@ -26,10 +26,9 @@ class SmartDataViz(Resource):
     class _getSmartDataVizs(Route):
         name = "getSmartDataVizs"
         httpMethod = Route.GET
-        path = "/projects/{project_ID}/datasets/{dataset_ID}/smartDataViz/"
+        path = "/projects/{project_ID}/smartDataViz/"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
-            'dataset_ID': Route.VALIDATOR_OBJECTID,
         }
 
     class _deleteSmartDataViz(Route):


### PR DESCRIPTION
**Updating route :**

_**1.**_ This route allows the user to get all the smartdataviz for a dataset.
`/projects/{project_ID}/smartDataViz/`


**Usage :**

_**1.**_ `api.SmartDataViz.computesmartdataviz(project_ID="project_ID")`


**Returns :**

_**1.**_  - 201 Success : All SmartDataViz
              - 500 Error : SmartDataViz FindAll Failed