### PR TITLE
fix bug on missing 'modified' field on datasets

### DIFF
--- a/hyper_api/base.py
+++ b/hyper_api/base.py
@@ -7,4 +7,6 @@ class Base(object):
 
     @staticmethod
     def str2date(string, date_format):
+        if string is None:
+            return None
         return datetime.strptime(string, date_format)

--- a/hyper_api/dataset.py
+++ b/hyper_api/dataset.py
@@ -381,7 +381,7 @@ class Dataset(Base):
             self.description,
             self.size,
             self.created.strftime('%Y-%m-%d %H:%M:%S UTC'),
-            self.modified.strftime('%Y-%m-%d %H:%M:%S UTC'),
+            self.modified.strftime('%Y-%m-%d %H:%M:%S UTC') if self.modified is not None else "",
             self.source_file_name)
 
     # Factory part


### PR DESCRIPTION
Under some conditons, the 'modified' field is missing on dataset object.
In this case, the API now successfully displays the list of datasets in the project
