### PR TITLE
Add option keepVariableName in DatasetFactory

### DIFF
--- a/HyperAPI/hyper_api/dataset.py
+++ b/HyperAPI/hyper_api/dataset.py
@@ -681,7 +681,7 @@ class Dataset(Base):
                 str(var).strip().replace("\n", "")
                 for var in dataframe.columns
             ])
-        keepVariableName =  'true' if set(newNames) <= set(oldNames) else 'false'
+        keepVariableName =  'true' if newNames <= oldNames else 'false'
         discreteDict = self.get_discreteDict()
         dataset = DatasetFactory(self.__api, self.project_id).create_from_dataframe(name, dataframe,  
                     description=description, modalities=modalities,  

--- a/HyperAPI/hyper_api/dataset.py
+++ b/HyperAPI/hyper_api/dataset.py
@@ -83,9 +83,12 @@ class DatasetFactory:
 
                 try:
                     self.__api.handle_work_states(project_id, work_type='datasetValidation', query={"datasetId": creation_json.get('_id')})
+                except Exception as E:
+                    raise ApiException('Unable to get the dataset validation status', str(E))
+                try:
                     self.__api.handle_work_states(project_id, work_type='datasetDescription', query={"datasetId": creation_json.get('_id')})
                 except Exception as E:
-                    raise ApiException('Unable to get the dataset status', str(E))
+                    raise ApiException('Unable to get the dataset description status', str(E))
 
                 returned_json = self.__api.Datasets.getadataset(project_ID=project_id, dataset_ID=creation_json.get('_id'))
                 return json, returned_json
@@ -218,11 +221,11 @@ class DatasetFactory:
         try:
             self.__api.handle_work_states(project_id, work_type='datasetValidation', query={"datasetId": creation_json.get('_id')})
         except Exception as E:
-            raise ApiException('Unable to get the dataset status', str(E))
+            raise ApiException('Unable to get the dataset validation status', str(E))
         try:
             self.__api.handle_work_states(project_id, work_type='datasetDescription', query={"datasetId": creation_json.get('_id')})
         except Exception as E:
-            raise ApiException('Unable to get the dataset status2', str(E))
+            raise ApiException('Unable to get the dataset description status', str(E))
         returned_json = self.__api.Datasets.getadataset(project_ID=project_id, dataset_ID=creation_json.get('_id'))
 
         return Dataset(self.__api, json_, returned_json)
@@ -266,9 +269,12 @@ class DatasetFactory:
 
         try:
             self.__api.handle_work_states(project_id, work_type='datasetValidation', query={"datasetId": creation_json.get('_id')})
+        except Exception as E:
+            raise ApiException('Unable to get the dataset validation status', str(E))
+        try:
             self.__api.handle_work_states(project_id, work_type='datasetDescription', query={"datasetId": creation_json.get('_id')})
         except Exception as E:
-            raise ApiException('Unable to get the dataset status', str(E))
+            raise ApiException('Unable to get the dataset description status', str(E))
 
         returned_json = self.__api.Datasets.getadataset(project_ID=project_id, dataset_ID=creation_json.get('_id'))
 

--- a/HyperAPI/hyper_api/dataset.py
+++ b/HyperAPI/hyper_api/dataset.py
@@ -138,7 +138,7 @@ class DatasetFactory:
     @Helper.try_catch
     def create_from_dataframe(self, name, dataframe, description='', modalities=2,
                               continuous_threshold=0.95, missing_threshold=0.95,
-                              metadata=None, discreteDict=None):
+                              metadata=None, discreteDict=None, keepVariableName=None):
         """
         Create a Dataset from a Pandas DataFrame
 
@@ -186,6 +186,9 @@ class DatasetFactory:
             'percentageContinuousThreshold': str(continuous_threshold),
             'percentageMissingThreshold': str(missing_threshold)
         }
+
+        if keepVariableName:
+            data['keepVariableName'] = keepVariableName
 
         data['file[0]'] = (
             file_name,
@@ -669,5 +672,5 @@ class Dataset(Base):
         dataset = DatasetFactory(self.__api, self.project_id).create_from_dataframe(name, dataframe,  
                     description=description, modalities=modalities,  
                     continuous_threshold=continuous_threshold, missing_threshold=missing_threshold, 
-                    metadata=metadata, discreteDict=discreteDict)
+                    metadata=metadata, discreteDict=discreteDict, keepVariableName='true')
         return dataset

--- a/HyperAPI/hyper_api/dataset.py
+++ b/HyperAPI/hyper_api/dataset.py
@@ -22,7 +22,7 @@ class DatasetFactory:
     def create(self, name, file_path, decimal='.',
                delimiter=';', encoding='UTF-8', selectedSheet=1,
                description='', modalities=2, continuous_threshold=0.95, missing_threshold=0.95,
-               metadata_file_path=None, discreteDict_file_path=None):
+               metadata_file_path=None, discreteDict_file_path=None, keepVariableName=None):
         """
         Create a Dataset from a file (csv, Excel)
 
@@ -71,6 +71,9 @@ class DatasetFactory:
             'percentageContinuousThreshold': str(continuous_threshold),
             'percentageMissingThreshold': str(missing_threshold)
         }
+
+        if keepVariableName:
+            data['keepVariableName'] = keepVariableName
 
         def apihandle():
                 json = {'project_ID': project_id, 'data': data, 'streaming': True}


### PR DESCRIPTION
When encoding a dataframe from an existing dataframe (useful for a scikit model), we want to keep the original variable names.  