### PR TITLE
Build pipeline uses PACKAGE_VERSION variable to set wheel's version

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,11 +18,12 @@ phases:
   build:
     commands:
       - export GIT_SOURCE_VERSION=$(git rev-parse HEAD)
+      - export WHEEL_FILENAME="HyperAPI-$PACKAGE_VERSION-py3-none-any.whl"
       - echo "Building HyperAPI Wheel"
       - python setup.py sdist bdist_wheel
-      - aws s3 cp dist/HyperAPI-5-py3-none-any.whl s3://pypi.hcube.cool/HyperAPI/HyperAPI-5-py3-none-any.whl
+      - aws s3 cp dist/$WHEEL_FILENAME s3://pypi.hcube.cool/HyperAPI/$WHEEL_FILENAME
       - echo "Installing HyperAPI's environment"
-      - pip install dist/HyperAPI-5-py3-none-any.whl
+      - pip install dist/$WHEEL_FILENAME
       - echo "Generating HyperAPI documentation sources"
       - cd $CODEBUILD_SRC_DIR/docs; chmod +x generate_doc.sh; ./generate_doc.sh $CODEBUILD_SRC_DIR/HyperAPI/hyper_api $DOCUUID
       - python $CODEBUILD_SRC_DIR/scripts/deploy.py -p $CODEBUILD_SRC_DIR/docs/$DOCUUID

--- a/package_metadata.json
+++ b/package_metadata.json
@@ -1,6 +1,5 @@
 {
     "name": "HyperAPI",
-    "version": "5",
     "author": "HyperCube",
     "author_email": "support@hypercube-research.com",
     "description": "HyperCube API",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ with open('requirements.txt') as f:
 with open('package_metadata.json') as m:
     setup_metadata = json.load(m)
 
+setup_metadata['version'] = os.environ.get('PACKAGE_VERSION', '999.1-dev')
+
 setup_kwargs = {
     "long_description": "HyperCube API",
     "long_description_content_type": "text/markdown",


### PR DESCRIPTION
This PR introduces the `PACKAGE_VERSION` variable that defines the generated wheel's version.
This variable has to be set in CodeBuild overrides when triggering a build.
When this variable is not defined, the wheel's version defaults to `999.1-dev`.