### PR TITLE
Add publish to ETL routes for Control Charts and Reshapes

### DIFF
--- a/HyperAPI/hdp_api/routes/datasetReshapes.py
+++ b/HyperAPI/hdp_api/routes/datasetReshapes.py
@@ -1,4 +1,5 @@
 from HyperAPI.hdp_api.routes import Resource, Route
+from HyperAPI.hdp_api.routes.base.version_management import available_since
 
 
 class DatasetReshapes(Resource):
@@ -51,6 +52,16 @@ class DatasetReshapes(Resource):
         name = "inheritReshape"
         httpMethod = Route.POST
         path = "/projects/{project_ID}/reshapes/{reshape_ID}/inherit"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'reshape_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    @available_since('3.3')
+    class _publishReshapeToEtl(Route):
+        name = "publishReshapeToEtl"
+        httpMethod = Route.POST
+        path = "/projects/{project_ID}/reshapes/{reshape_ID}/etlpublish"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'reshape_ID': Route.VALIDATOR_OBJECTID,

--- a/HyperAPI/hdp_api/routes/optimProcess.py
+++ b/HyperAPI/hdp_api/routes/optimProcess.py
@@ -1,4 +1,5 @@
 from HyperAPI.hdp_api.routes import Resource, Route
+from HyperAPI.hdp_api.routes.base.version_management import available_since
 
 
 class OptimProcess(Resource):
@@ -42,6 +43,16 @@ class OptimProcess(Resource):
         name = "updateControlChart"
         httpMethod = Route.POST
         path = "/optimProcess/projects/{project_ID}/controlCharts/{controlChart_ID}"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'controlChart_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    @available_since('3.3')
+    class _publishControlChartToEtl(Route):
+        name = "PublishControlChartToEtl"
+        httpMethod = Route.POST
+        path = "/optimProcess/projects/{project_ID}/controlCharts/{controlChart_ID}/etlpublish"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'controlChart_ID': Route.VALIDATOR_OBJECTID,


### PR DESCRIPTION
Routes (available on hdp version >= 3.3): 
- Publish a Control Chart to the ETL:
`POST /optimProcess/projects/{project_ID}/controlCharts/{controlChart_ID}/etlpublish`
- Publish a Reshape to the ETL
`POST /projects/{project_ID}/reshapes/{reshape_ID}/etlpublish`