### PR TITLE
[5.1.7] Add get Forecast Tunes Stats to Nitro routes for ForecastTunes

### DIFF
--- a/HyperAPI/hdp_api/routes/nitro.py
+++ b/HyperAPI/hdp_api/routes/nitro.py
@@ -124,3 +124,15 @@ class Nitro(Resource):
             'dataset_ID': Route.VALIDATOR_OBJECTID,
             'forecast_ID': Route.VALIDATOR_OBJECTID
         }
+
+    @available_since('3.5')
+    class _getForecastTunesStats(Route):
+        name = "getForecastTunesStats"
+        httpMethod = Route.POST
+        path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/stats"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'forecast_ID': Route.VALIDATOR_OBJECTID
+        }
+

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,13 @@
 
 ## 5.1
 
-### 5.1.6 - 3rd Parties Routes
+### 5.1.7 - Nitro Forecast Tunes Stats
+
+- Adding Route `nitro.getForecastTunesStats`
+    - Available since HDP 3.5
+    - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/stats`
+
+### 5.1.6 - Adding Lasso Model
 
 - Adding Lasso model
 


### PR DESCRIPTION
Routes (available on hdp version >= 3.5): 
- get Forecast Tunes Stats to Nitro routes for ForecastTunes:
`POST /nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/stats`
