### PR TITLE
[6.0.2] Split codebuild definitions into build and tests + incremental doc update

### DIFF
--- a/HyperAPI/hdp_api/README.md
+++ b/HyperAPI/hdp_api/README.md
@@ -1,0 +1,1 @@
+# HDP_API Developper Documentation

--- a/HyperAPI/hdp_api/base/README.md
+++ b/HyperAPI/hdp_api/base/README.md
@@ -3,38 +3,61 @@
 This module contains base implementations for Resources, Routes and version management.
 - [Resource Abstract Class](#resource_class)
 - [Route Abstract Class](#route_class)
+- [SubRoute Abstract Class](#subroute_class)
+- [Resource and Routes definition example](#example)
 
 <a name="resource_class"></a>
 
 ## Resource Abstract Class
 
 Defines a resource which is a Route container as defined in the `hypercubeApi.json` file on HDP. 
-Resources are instanciated when the `HyperAPI.hdp_api.Router` is instanciated and a session is opened. 
+Resources are instanciated when the `HyperAPI.hdp_api.base.Router` is instanciated and a session is opened. 
 
-When a resource is created, all `HyperAPI.hdp_api.routes.Route` classes defined within a resource are also instanciated if their hdp_version requirements are met. 
+When a resource is created, all `HyperAPI.hdp_api.base.Route` classes defined within a resource are also instanciated if their hdp_version requirements are met. 
 
 Resources are iterables, yielding every routes they contains. 
 
-### Properties to define
+### Attributes and properties
 
-#### Available Since
-The HDP version on which the resource was created. The resource will only be created and available if the API connects to a HDP server of that version (included) and above. 
-
-_Expected Format_: str
-
-
-#### Removed Since
-The HDP version on which the resource was deleted. The resource not be available if the API connects to a HDP server of that version (included) onwards. 
-
-_Expected Format_: str
-
-
-#### Name
+#### name (abstract property, must be defined in all subclasses)
 The name of the resource as stated in the `hypercubeApi.json` file on HDP. The name must be an exact match. 
 
 _Expected Format_: str
 
+#### available_since
+The HDP version on which the resource was created. The resource will only be created and available if the API connects to a HDP server of that version (included) and above. 
+
+_Expected Format_: str (must be a suitable hdp version string)
+_Default Value_: 0 (will be converted to `Version(0.0.0)`)
+
+#### removed_since
+The HDP version on which the resource was deleted. The resource not be available if the API connects to a HDP server of that version (included) onwards. 
+
+_Expected Format_: str (must be a suitable hdp version string)
+_Default Value_: None (will be converted to `Version(None)`)
+
+#### unavailable_on
+Specific HDP versions on which the resource is not available. This setting takes precedence over `available_since` setting.
+
+_Expected Format_: str[] (must be a list of suitable hdp version string)
+_Default Value_: []
+
+### Public Methods
+
+#### is_available(version)
+Classmethod. Returns true if the resource is available for the specified version, false otherwise. `version` must be a valid hdp version string or a `HyperAPI.utils.version.Version` instance.
+
+#### check_routes_integrity()
+Classmethod. Checks the integrity of all routes defined in the ressource. 
 
 <a name="route_class"></a>
 
 ## Route Abstract Class
+
+<a name="subroute_class"></a>
+
+## SubRoute Abstract Class
+
+<a name="example"></a>
+
+## Resource and Routes definition example

--- a/HyperAPI/hdp_api/base/router.py
+++ b/HyperAPI/hdp_api/base/router.py
@@ -150,7 +150,8 @@ class Router(object):
 
     def __iter__(self):
         for resourceCls in self._resources:
-            yield self.__getattribute__(resourceCls.__name__)
+            if resourceCls.is_available(self.session.version):
+                yield self.__getattribute__(resourceCls.__name__)
 
     # Work Management Specific Code ---------------------------------------------------------------------
 

--- a/HyperAPI/hdp_api/routes/correlations.py
+++ b/HyperAPI/hdp_api/routes/correlations.py
@@ -7,9 +7,13 @@ class Correlations(Resource):
     available_since = "1.0"
     removed_since = None
 
-    class _GetCorrelations(Route):
+    # Old correlation class names for 4.3 ---------------------------------------------------------
+
+    class _InitListofCorrelations(Route):
         name = "GetCorrelations"
         httpMethod = Route.GET
+        available_since = "1.0"
+        removed_since = "3.0"
         path = "/projects/{project_ID}/correlations"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
@@ -18,8 +22,114 @@ class Correlations(Resource):
     class _NewCorrelation(Route):
         name = "New Correlation"
         httpMethod = Route.POST
+        available_since = "1.0"
         removed_since = "3.0"
         path = "/projects/{project_ID}/tasks/new"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _GetNewJSONfile(Route):
+        name = "Get new JSON file"
+        httpMethod = Route.GET
+        available_since = "1.0"
+        removed_since = "3.0"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'correlation_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _GetJSONfile(Route):
+        name = "Get JSON file"
+        httpMethod = Route.GET
+        available_since = "1.0"
+        removed_since = "3.0"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/correlation/{correlation_ID}"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'correlation_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+
+    class _GetNewCSVfile(Route):
+        name = "Get new CSV file"
+        httpMethod = Route.GET
+        available_since = "1.0"
+        removed_since = "3.0"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/export"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'correlation_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _GetCSVfile(Route):
+        name = "Get CSV file"
+        httpMethod = Route.GET
+        available_since = "1.0"
+        removed_since = "3.0"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/export"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'correlation_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _CreateNewCorrelation(Route):
+        name = "CreateNewCorrelation"
+        httpMethod = Route.POST
+        available_since = "1.0"
+        removed_since = "3.0"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/correlations"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _RenameNewCorrelation(Route):
+        name = "RenamNewCorrelation"
+        httpMethod = Route.POST
+        available_since = "1.0"
+        removed_since = "3.0"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/rename"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'correlation_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _saveCorrelationImg(Route):
+        name = "saveCorrelationImg"
+        httpMethod = Route.POST
+        available_since = "1.0"
+        removed_since = "3.0"
+        path = "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/preview"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'correlation_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    class _retrieveCorrelationsPreview(Route):
+        name = "retrieveCorrelationsPreview"
+        httpMethod = Route.GET
+        available_since = "1.0"
+        removed_since = "3.0"
+        path = "/projects/{project_ID}/correlations/previews"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+        }
+
+    # Correaltions new naming since HDP version 3.0 -----------------------------------------------
+
+    class _GetCorrelations(Route):
+        name = "GetCorrelations"
+        httpMethod = Route.GET
+        available_since = "2.0"
+        path = "/projects/{project_ID}/correlations"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
         }
@@ -88,17 +198,6 @@ class Correlations(Resource):
         name = "UpdateCorrelationPreview"
         httpMethod = Route.POST
         path = "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/preview"
-        _path_keys = {
-            'project_ID': Route.VALIDATOR_OBJECTID,
-            'dataset_ID': Route.VALIDATOR_OBJECTID,
-            'correlation_ID': Route.VALIDATOR_OBJECTID,
-        }
-
-    class _RetrieveCorrelationsPreview(Route):
-        name = "retrieveCorrelationsPreview"
-        httpMethod = Route.GET
-        removed_since = "3.0"
-        path = "/projects/{project_ID}/correlations/previews"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'dataset_ID': Route.VALIDATOR_OBJECTID,

--- a/README.md
+++ b/README.md
@@ -4,28 +4,90 @@ Let you access all your Data on HyperCube Data Platform
 
 visit https://www.hcube.io
 
-# Documentation
+# Requirements
+- Python 3.6.2
+- Pip
+
+# User Documentation
 
 [Direct link](http://hyperapi-doc.s3-website.eu-west-3.amazonaws.com/29dc2abb-fc26-403e-bad0-0088c7640168/index.html)
 
 # Quick installation
 
-In order to run the HyperAPI module, you need at least Python v3.6+ installed on your system and running as the main python environment. Then you need to install PiPy and do the following commands.
+_on windows_
 
-#### On Linux and MacOS
-````
-$> python --version
-Python 3.6.5
-````
+```pip install --upgrade HyperAPI``` 
 
-````
-# Taking into account that your main python is Python 3.6+
-$> curl -O https://bootstrap.pypa.io/get-pip.py
-$> python get-pip.py
-$> python pip install -r requirements.txt
-````
-Then you can run a python prompt
-````
-$> PYTHONPATH=<path to the HyperAPI directory> python
-import HyperAPI
-````
+_on linux/mac_
+
+```pip3 install --upgrade HyperAPI```
+
+Sample python code : 
+
+```
+from HyperAPI.hdp_api import Router
+api = Router(token="USER_TOKEN", url="https://trial.hcube.io")
+
+```
+# Dev Documentation
+
+[Direct link](https://HyperCube/HyperAPI/hdp_api/README.md)
+
+# Building and installing the HyperAPI module manually
+
+### Building the python wheel
+
+From the repository root folder, run the following command lines:
+
+Set an environment variable `PACKAGE_VERSION` the define the version number for the HyperAPI. 
+
+_on windows_
+
+```set PACKAGE_VERSION=x``` 
+
+_on linux/mac_
+
+```export PACKAGE_VERSION=x```
+
+Generate the HyperAPI wheel file. 
+
+_on windows_
+
+```python setup.py sdist bdist_wheel```
+
+_on linux/mac_
+
+```python setup.py sdist bdist_wheel```
+
+The file will be generated on the in the `/dist` folder and be named HyperAPI-_x_-py3-none-any.whl _x_ being the provided version number.
+
+### Installing the python wheel
+
+The wheel can be installed directly using pip: 
+
+_on windows_
+
+```pip install /dist/HyperAPI-_x_-py3-none-any.whl```
+
+_on linux/mac_
+
+```pip3 install /dist/HyperAPI-_x_-py3-none-any.whl```
+
+# Using the module from the source files 
+
+- *Option 1:* run python from the source forlder:
+- *Option 2:* add the HyperAPI folder to the python path:
+
+### Option 2
+
+# Running Tests
+
+From the Repository root folder run the following command line:
+
+_on windows_
+
+```python -m unittest discover -s tests -p "*_test.py" -v```
+
+_on linux/max_
+
+```python3 -m unittest discover -s tests -p "*_test.py" -v```

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,0 +1,5 @@
+Sphinx==1.7.6
+guzzle_sphinx_theme==0.7.11
+sphinxcontrib-napoleon==0.6.1
+sphinx_bootstrap_theme==0.6.5
+IPython

--- a/changelog.md
+++ b/changelog.md
@@ -30,15 +30,19 @@
 
 - Adding _README.md_ and _CHANGELOG.md_ files. 
 
-- Session details (coming from the _system/about_ route) are now stored in the `hdp_api.Router` instance. Display from the `hyper_api.Api` instance has been changed accordingly. 
+- Updated file hierarchy for `hdp_api` module : `Route`, `Resource`and `Router` base classes have been moved to the `hdp_api.base` module.
 
-- Added properties `available_since` and `removed_since` on `hdp_api.routes.Resource` so no resources are created on incompatible HDP versions. 
+- Session details (coming from the _system/about_ route) are now stored in the `hdp_api.base.Router` instance. Display from the `hyper_api.Api` instance has been changed accordingly. 
+
+- Added properties `available_since` and `removed_since` on `hdp_api.base.Resource` so no resources are created on incompatible HDP versions. 
 All resources files have been updated accordingly. 
 
-- Removed `available_since`, `deprecated_since` and `reroute` decorators for `hdp_api.routes.Route`. `available_since` is now handled as abstract properties on `hdp_api.routes.Route`.
-- Added `removed_since` property on `hdp_api.routes.Route`. Routes are not created if the HDP version is equal or above that version. This behaviour replaces the `deprecated_since` decorator. 
-- Routes compatiblity between HDP versions is no longer managed using the `reroute` decorator but uses the ``hdp_api.routes.Route.reroute_to` class method, which dynamically creates variants for the parent route. 
+- Removed `available_since`, `deprecated_since` and `reroute` decorators for `hdp_api.base.Route`. `available_since` is now handled as abstract properties on `hdp_api.routes.Route`.
+- Added `removed_since` property on `hdp_api.base.Route`. Routes are not created if the HDP version is equal or above that version. This behaviour replaces the `deprecated_since` decorator. 
+- Routes compatiblity between HDP versions is no longer managed using the `reroute` decorator but uses the ``hdp_api.base.Route.SubRoute` class which defines variants for the parent route. 
 All routes have been updated accordingly.
+
+- Add unittests files to test class methods and behaviour. 
 
 ## 5.2 - Refactoring of Projects and Datasets routes
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,46 @@
 
 ## Version 6
 
+### 6.0.2
+
+- Fix resource iterator
+- Add correlations compatibility routes for HyperCube 4.3
+ - Adding Route `Correlations.NewCorrelation`
+    - Removed since HDP 3.0
+    - POST `/projects/{project_ID}/tasks/new`
+
+ - Adding Route `Correlations.GetNewJSONfile`
+    - Removed since HDP 3.0
+    - POST `/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}`
+
+ - Adding Route `Correlations.GetJSONfile`
+    - Removed since HDP 3.0
+    - GET `/projects/{project_ID}/datasets/{dataset_ID}/correlation/{correlation_ID}`
+
+ - Adding Route `Correlations.GetNewCSVfile`
+    - Removed since HDP 3.0
+    - GET `/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/export`
+
+ - Adding Route `Correlations.GetCSVfile`
+    - Removed since HDP 3.0
+    - GET `/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/export`
+
+ - Adding Route `Correlations.InitListOfCorrelations`
+    - Removed since HDP 3.0
+    - GET `/projects/{project_ID}/correlations`
+
+ - Adding Route `Correlations.CreateNewCorrelation`
+    - Removed since HDP 3.0
+    - POST `/projects/{project_ID}/datasets/{dataset_ID}/correlations`
+
+ - Adding Route `Correlations.RenameNewCorrelation`
+    - Removed since HDP 3.0
+    - POST `/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/rename`
+
+ - Adding Route `Correlations.retrieveCorrelationsPreview`
+    - Removed since HDP 3.0
+    - GET `/projects/{project_ID}/correlations/previews`
+
 ### 6.0.1
 
 - Added new router 'IoT' containing the routes listed below.

--- a/codebuild_build.yml
+++ b/codebuild_build.yml
@@ -16,12 +16,9 @@ phases:
       - echo "Running Unit Tests"
       - pip install pyjwt
       - python -m unittest discover -s $CODEBUILD_SRC_DIR/tests -p "*_test.py" -v
-      - echo "Running Linter"
-      - pip install flake8
-      - python -m flake8 --exit-zero --ignore E501,W503,W504 $CODEBUILD_SRC_DIR/docs/HyperAPI
       - echo "Logging into Amazon ECR..."
       - $(aws ecr get-login --no-include-email --region eu-central-1)
-      - echo "Setupping Twine"
+      - echo "Setup Twine"
       - aws s3 cp s3://ops.hcube.cool/pypi/password.txt ./password.txt && export TWINE_USERNAME=admin && export TWINE_PASSWORD=$(cat password.txt) && export TWINE_REPOSITORY_URL=https://pypi.hcube.cool/simple
   build:
     commands:
@@ -29,9 +26,9 @@ phases:
       - export WHEEL_FILENAME="HyperAPI-$PACKAGE_VERSION-py3-none-any.whl"
       - echo "Building HyperAPI Wheel"
       - python setup.py sdist bdist_wheel
-      - twine upload --skip-existing dist/$WHEEL_FILENAME
+      - twine upload $CODEBUILD_SRC_DIR/dist/$WHEEL_FILENAME
       - echo "Installing HyperAPI's environment"
-      - pip install dist/$WHEEL_FILENAME
+      - pip install -r build_requirements.txt
       - echo "Generating HyperAPI documentation sources"
       - cd $CODEBUILD_SRC_DIR/docs; chmod +x generate_doc.sh; ./generate_doc.sh $CODEBUILD_SRC_DIR/HyperAPI/hyper_api $DOCUUID
       - python $CODEBUILD_SRC_DIR/scripts/deploy.py -b hyperapi.hcube.cool -p $CODEBUILD_SRC_DIR/docs/$DOCUUID -r eu-central-1
@@ -40,3 +37,4 @@ phases:
       - docker build -t hyperapi . --build-arg hyperapiversion=$PACKAGE_VERSION
       - docker tag hyperapi:latest $ECR_TARGET:$GIT_SOURCE_VERSION
       - docker push $ECR_TARGET:$GIT_SOURCE_VERSION
+      - echo "Build Done"

--- a/codebuild_test.yml
+++ b/codebuild_test.yml
@@ -3,12 +3,12 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - echo "Running Unit Tests"
-      - pip install -r $CODEBUILD_SRC_DIR/requirements.txt
-      - python -m unittest discover -s $CODEBUILD_SRC_DIR/tests -p "*_test.py" -v
       - echo "Running Linter"
       - pip install flake8
       - python -m flake8 --ignore E501,W503,W504 $CODEBUILD_SRC_DIR/docs/HyperAPI
+      - echo "Running Unit Tests"
+      - pip install -r $CODEBUILD_SRC_DIR/requirements.txt
+      - python -m unittest discover -s $CODEBUILD_SRC_DIR/tests -p "*_test.py" -v
   build:
     commands:
       - export WHEEL_FILENAME="HyperAPI-$PACKAGE_VERSION-py3-none-any.whl"

--- a/codebuild_test.yml
+++ b/codebuild_test.yml
@@ -1,0 +1,19 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo "Running Unit Tests"
+      - pip install -r $CODEBUILD_SRC_DIR/requirements.txt
+      - python -m unittest discover -s $CODEBUILD_SRC_DIR/tests -p "*_test.py" -v
+      - echo "Running Linter"
+      - pip install flake8
+      - python -m flake8 --ignore E501,W503,W504 $CODEBUILD_SRC_DIR/docs/HyperAPI
+  build:
+    commands:
+      - export WHEEL_FILENAME="HyperAPI-$PACKAGE_VERSION-py3-none-any.whl"
+      - echo "Building HyperAPI Wheel"
+      - python setup.py sdist bdist_wheel
+      - echo "Installing HyperAPI's environment"
+      - pip install $CODEBUILD_SRC_DIR/dist/$WHEEL_FILENAME
+      - echo "Build Done"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
-Sphinx==1.7.6
-guzzle_sphinx_theme==0.7.11
-sphinxcontrib-napoleon==0.6.1
-sphinx_bootstrap_theme==0.6.5
 pyjwt
 requests
 requests_toolbelt==0.8.0
-boto3==1.7.4
-IPython


### PR DESCRIPTION
### Changes:
- Update doc
- the buildspec file has been split into 2 separate files : 
  - codebuild_build.yml : generate doc, build and publish package 
  - codebuild_test.yml : linter and unit test for API
- Requirements have been split into package and build requirements. 
