### PR TITLE
[6.0.4]: Add 2 new Nitro routes (metadata & modalities)

### DIFF
--- a/HyperAPI/hdp_api/routes/nitro.py
+++ b/HyperAPI/hdp_api/routes/nitro.py
@@ -186,3 +186,25 @@ class Nitro(Resource):
             'dataset_ID': Route.VALIDATOR_OBJECTID,
             'forecast_ID': Route.VALIDATOR_OBJECTID
         }
+
+    class _getForecastTunesMetadata(Route):
+        name = "getForecastTunesMetadata"
+        available_since = '4.2.2'
+        httpMethod = Route.GET
+        path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/metadata"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'forecast_ID': Route.VALIDATOR_OBJECTID
+        }
+
+    class _getForecastTunesModalities(Route):
+        name = "getForecastTunesModalities"
+        available_since = '4.2.2'
+        httpMethod = Route.POST
+        path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/modalities"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'forecast_ID': Route.VALIDATOR_OBJECTID
+        }

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 ## Version 6
 
+### 6.0.5
+
+- Adding Route `getForecastTunesMetadata`
+    - Available since HDP 4.2.2
+    - GET `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/metadata`
+
+- Adding Route `getForecastTunesModalities`
+    - Available since HDP 4.2.2
+    - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/modalities`
+
 ### 6.0.4
 
 - Adding Route `datasetReshapes.exportSteps`

--- a/tests/data/schema_json/hdp_4.2.2.json
+++ b/tests/data/schema_json/hdp_4.2.2.json
@@ -1,0 +1,7558 @@
+{
+    "name": "HYPERCUBE API DOCUMENTATION",
+    "version": "4.2.2",
+    "title": "HYPERCUBE API",
+    "description": "Covers all Hypercube Api.",
+    "protocol": "rest",
+    "basePath": "http://localhost",
+    "publicPath": "/api/v1",
+    "resources": {
+        "Authentication": {
+            "methods": {
+                "login": {
+                    "name": "login",
+                    "description": "login",
+                    "httpMethod": "POST",
+                    "path": "/auth/login",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                },
+                "logout": {
+                    "name": "logout",
+                    "description": "logout",
+                    "httpMethod": "POST",
+                    "path": "/auth/logout",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                }
+            }
+        },
+        "Product": {
+            "methods": {
+                "info": {
+                    "name": "info",
+                    "description": "info",
+                    "httpMethod": "GET",
+                    "path": "/product/info",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                }
+            }
+        },
+        "Settings": {
+            "methods": {
+                "getUserSettings": {
+                    "name": "Get User Settings",
+                    "description": "Get User Settings",
+                    "httpMethod": "GET",
+                    "path": "/settings",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                },
+                "updateUserSettings": {
+                    "name": "Update User Settings",
+                    "description": "Update User Settings",
+                    "httpMethod": "POST",
+                    "path": "/settings",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    },
+                    "request": {
+                        "$ref": "UserModel"
+                    }
+                },
+                "resetUserApiToken": {
+                    "name": "Reset a user ApiToken",
+                    "description": "reset a user ApiToken in the system.",
+                    "httpMethod": "POST",
+                    "path": "/settings/resetApiToken",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                }
+            }
+        },
+        "Identities": {
+            "methods": {
+                "getAllIdentities": {
+                    "name": "Get all identities",
+                    "description": "List all identities in the system.",
+                    "httpMethod": "GET",
+                    "path": "/identities",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "getAllUsers": {
+                    "name": "Get all users",
+                    "description": "List all users in the system.",
+                    "httpMethod": "GET",
+                    "path": "/identities/users",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "addUser": {
+                    "name": "Add a user",
+                    "description": "Add a user in the system.",
+                    "httpMethod": "POST",
+                    "path": "/identities/users",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "request": {
+                        "$ref": "UserModel"
+                    }
+                },
+                "updateUser": {
+                    "name": "Update a user",
+                    "description": "Update a user in the system.",
+                    "httpMethod": "POST",
+                    "path": "/identities/users/{user_ID}",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "user_ID": {
+                            "default": "",
+                            "description": "User Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "request": {
+                        "$ref": "UserModel"
+                    }
+                },
+                "getAllGroups": {
+                    "name": "Get all groups",
+                    "description": "List all groups in the system.",
+                    "httpMethod": "GET",
+                    "path": "/identities/groups",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "addGroup": {
+                    "name": "Add a new group",
+                    "description": "Add a new group in the system.",
+                    "httpMethod": "POST",
+                    "path": "/identities/groups",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "request": {
+                        "$ref": "GroupModel"
+                    }
+                },
+                "updateGroup": {
+                    "name": "Update a group",
+                    "description": "update a group in the system.",
+                    "httpMethod": "POST",
+                    "path": "/identities/groups/{group_ID}",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "group_ID": {
+                            "default": "",
+                            "description": "Group Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "request": {
+                        "$ref": "GroupModel"
+                    }
+                },
+                "getIdentityById": {
+                    "name": "Get an identity",
+                    "description": "Get information about a specific identity.",
+                    "httpMethod": "GET",
+                    "path": "/identities/{identity_ID}",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "identity_ID": {
+                            "default": "",
+                            "description": "Identity Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteIdentity": {
+                    "name": "Delete an identity",
+                    "description": "Delete a identity Id.",
+                    "httpMethod": "POST",
+                    "path": "/identities/{identity_ID}/delete",
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "identity_ID": {
+                            "default": "",
+                            "description": "Identity Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "Projects": {
+            "methods": {
+                "getAllProjects": {
+                    "name": "Projects",
+                    "description": "List all projects",
+                    "httpMethod": "GET",
+                    "path": "/projects",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getOneProjectById": {
+                    "name": "Get a project",
+                    "description": "Get information about a specific project.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Want to retrieve information for this project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "addProject": {
+                    "name": "Add Project",
+                    "description": "Add a new project",
+                    "httpMethod": "POST",
+                    "path": "/projects",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "request": {
+                        "$ref": "ProjectModel"
+                    }
+                },
+                "updateProject": {
+                    "name": "Update project",
+                    "description": "Update project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/update",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to update.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteProject": {
+                    "name": "Delete project",
+                    "description": "Delete a specific Project Id.",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to delete.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "addSharedUsers": {
+                    "name": "Add shared users to project",
+                    "description": "Add shared users to project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/shared/add",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to update.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "removeSharedUsers": {
+                    "name": "Remove shared users to project",
+                    "description": "Remove shared users to project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/shared/remove",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to update.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "clearSharedUsers": {
+                    "name": "Clear shared users of project",
+                    "description": "Clear shared users of project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/shared/clear",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to update.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getRelevantSharedUsers": {
+                    "name": "Get relevant users",
+                    "description": "Get relevant users",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/shared/relevant",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to update.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "Tags": {
+            "methods": {
+                "addTag": {
+                    "name": "add tag",
+                    "description": "add tag from tag management",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/variables/addTag",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to add tag.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "renameTag": {
+                    "name": "renameTag",
+                    "description": "rename Tag",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/tags/{tag_ID}/rename",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "tag_ID": {
+                            "default": "",
+                            "description": "tag Id to rename.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "addTags": {
+                    "name": "add tags",
+                    "description": "add tags when uploading a dataset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/variables/addTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to add tags.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "addMetaTags": {
+                    "name": "add metatag",
+                    "description": "add metatag",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/variables/tags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "deleteTag": {
+                    "name": "delete tag",
+                    "description": "delete tag",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/tags/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "editTag": {
+                    "name": "edit tag",
+                    "description": "edit tag",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/variables/tag",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "editMetatag": {
+                    "name": "edit metatag",
+                    "description": "edit metatag",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/metatype/tag",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "createMetatag": {
+                    "name": "create metatag",
+                    "description": "create tag",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/metatype/addTag",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "Datasets": {
+            "methods": {
+                "getAllDataset": {
+                    "name": "Datasets",
+                    "description": "List all datasets",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "addNewDatasetFromMongo": {
+                    "name": "addDatasets",
+                    "description": "Add a new dataset from mongo",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/addDatasetFromMongo",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "addNewConstrainedDataset": {
+                    "name": "addConstrainedDataset",
+                    "description": "Add a new dataset by applying constraints on an existing dataset (link)",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/addConstrainedDataset",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "addFolderDiffDataset": {
+                    "name": "addFolderDiffDataset",
+                    "description": "Add a new dataset of type DataLink",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/addFolderDiffDataset",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "description": "Id of the project",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "datasetName": {
+                            "description": "name of the dataset",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "Description of the dataset",
+                            "location": "body",
+                            "required": false,
+                            "type": "string"
+                        },
+                        "type": {
+                            "default": "folderDiff",
+                            "description": "Type of dataset",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "cached": {
+                            "default": "true",
+                            "description": "Is the dataset cached",
+                            "location": "body",
+                            "required": false,
+                            "type": "boolean"
+                        },
+                        "separator": {
+                            "default": "default",
+                            "description": "The separator of the dataset",
+                            "location": "body",
+                            "required": false,
+                            "type": "string"
+                        },
+                        "encoding": {
+                            "default": "default",
+                            "description": "The encoding of the dataset",
+                            "location": "body",
+                            "required": false,
+                            "type": "string"
+                        },
+                        "folderDiff": {
+                            "description": "The settings of the dataset folderDiff",
+                            "location": "body",
+                            "required": true,
+                            "type": "object",
+                            "properties": {
+                                "masterFolderPath": {
+                                    "description": "Master Folder Path",
+                                    "location": "body",
+                                    "required": true,
+                                    "type": "string"
+                                },
+                                "masterFilename": {
+                                    "description": "Master Filename",
+                                    "location": "body",
+                                    "required": true,
+                                    "type": "string"
+                                },
+                                "diffsFolderPath": {
+                                    "description": "Diffs Folder Path",
+                                    "location": "body",
+                                    "required": true,
+                                    "type": "string"
+                                },
+                                "diffsFilenamePattern": {
+                                    "description": "Diffs Filename Pattern",
+                                    "location": "body",
+                                    "required": true,
+                                    "type": "string"
+                                },
+                                "metadataFilePath": {
+                                    "description": "Metadata FilePath",
+                                    "location": "body",
+                                    "required": false,
+                                    "type": "string"
+                                },
+                                "aggregationKeys": {
+                                    "description": "Aggregation Keys",
+                                    "location": "body",
+                                    "required": true,
+                                    "type": "array",
+                                    "items": {
+                                        "title": "key",
+                                        "description": "Key to aggregate master and diff",
+                                        "required": true,
+                                        "type": "string"
+                                    }
+                                },
+                                "joinFiles": {
+                                    "description": "Join Files",
+                                    "location": "body",
+                                    "required": false,
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "filePath": {
+                                            "description": "File to join Path",
+                                            "location": "body",
+                                            "required": true,
+                                            "type": "string"
+                                        },
+                                        "key": {
+                                            "description": "File to join Key of merge",
+                                            "location": "body",
+                                            "required": true,
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "storage": {
+                                    "description": "Input Storage Configuration",
+                                    "location": "body",
+                                    "required": true,
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Type of storage to use",
+                                            "location": "body",
+                                            "required": true,
+                                            "type": "string"
+                                        },
+                                        "bucket": {
+                                            "description": "S3 bucket",
+                                            "location": "body",
+                                            "required": false,
+                                            "type": "string"
+                                        },
+                                        "region": {
+                                            "description": "S3 region",
+                                            "location": "body",
+                                            "required": false,
+                                            "type": "string"
+                                        },
+                                        "credentials": {
+                                            "description": "S3 authentication",
+                                            "location": "body",
+                                            "required": false,
+                                            "type": "object",
+                                            "properties": {
+                                                "accessKeyId": "string",
+                                                "secretAccessKey": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "createDataset": {
+                    "name": "createDataset",
+                    "description": "Create a new dataset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/create",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "description": "The parent project ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "datasetName": {
+                            "description": "name of the dataset",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "Description of the dataset",
+                            "location": "body",
+                            "required": false,
+                            "type": "string"
+                        },
+                        "type": {
+                            "default": "csv",
+                            "description": "Type of dataset",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "cached": {
+                            "default": "true",
+                            "description": "Is the dataset copied and stored locally",
+                            "location": "body",
+                            "required": false,
+                            "type": "boolean"
+                        },
+                        "separator": {
+                            "default": "default",
+                            "description": "The separator of the dataset",
+                            "location": "body",
+                            "required": false,
+                            "type": "string"
+                        },
+                        "encoding": {
+                            "default": "default",
+                            "description": "The encoding of the dataset",
+                            "location": "body",
+                            "required": false,
+                            "type": "string"
+                        }
+                    }
+                },
+                "saveAsNewDataset": {
+                    "name": "saveAsNewDataset",
+                    "description": "Save as new dataset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/saveAsNewDataset",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "getXvalues": {
+                    "name": "getXvalues",
+                    "description": "get Xvalues",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/xvalues/{columns_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "uploadDataset": {
+                    "name": "UploadDatasets",
+                    "description": "Add new dataset with MULTER",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/add",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Id of the project",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "datasetName": {
+                            "default": "",
+                            "description": "name of the project",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": {
+                            "default": "",
+                            "description": "Description of the project",
+                            "location": "path",
+                            "required": false,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getOneDatasetById": {
+                    "name": "Get a dataset",
+                    "description": "Get information about a specific dataset.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Want to retrieve information for this dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "filteredGrid": {
+                    "name": "filtered Grid",
+                    "description": "filtered Grid",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/filteredGrid",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "defaultResampling": {
+                    "name": "Default Resampling",
+                    "description": "Default resampling",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/defaultResampling",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "tempData": {
+                    "name": "getDatasetTempData",
+                    "description": "temp Data",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/tempData",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getStats": {
+                    "name": "Stats",
+                    "description": "Retrieve dataset's stats file.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/stats",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getVariablesStats": {
+                    "name": "getVariablesStats",
+                    "description": "getVariablesStats",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/stats/variables",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getModalites": {
+                    "name": "getModalites",
+                    "description": "getModalites",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/stats/modalities",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "refreshCache": {
+                    "name": "refreshCache",
+                    "description": "Refresh the cached data of a datalink",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/refreshCache",
+                    "features": [
+                        "datalink"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteDataset": {
+                    "name": "Delete dataset",
+                    "description": "Delete a specific Project Id.",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id to delete.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportDatasetAsCSV": {
+                    "name": "ExportCSV",
+                    "description": "Export a dataset as a CSV file.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/exportCSV",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id to export.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportMetadata": {
+                    "name": "Export metadata",
+                    "description": "Export metadata from specific dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/metadata/export",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id to delete.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to delete.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportDiscreteDict": {
+                    "name": "Export discreteDict",
+                    "description": "Export discreteDict from specific dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/discreteDict/export",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id to delete.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to delete.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getSample": {
+                    "name": "getSample",
+                    "description": "get sample of a dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/sample",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "updateMetadata": {
+                    "name": "metadata",
+                    "description": "update metadata",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/metadata",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "importMetadata": {
+                    "name": "Import metadata",
+                    "description": "Import metadata from specific dataset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/metadata/import",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id to delete.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id to delete.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "dataValidationLog": {
+                    "name": "dataValidationLog",
+                    "description": "get stat.json",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/dataValidationLog",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "readMetadata": {
+                    "name": "readMetadata",
+                    "description": "read metadata",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/readMetadata",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "readDiscreteDict": {
+                    "name": "readDiscreteDict",
+                    "description": "read discrete dict",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/readDiscreteDict",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "split": {
+                    "name": "split",
+                    "description": "Split dataset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/split",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "sample": {
+                    "name": "sample",
+                    "description": "Sample dataset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/sample",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "discretize": {
+                    "name": "discretize",
+                    "description": "Launch the discretization computations",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/discretize",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteDiscretization": {
+                    "name": "deleteDiscretization",
+                    "description": "Remove a discretization from the metadata",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/deleteDiscretization",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getEstimate": {
+                    "name": "getEstimate",
+                    "description": "Estimate dataset size",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/estimate",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "setEstimate": {
+                    "name": "setEstimate",
+                    "description": "Estimate dataset size",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/estimate",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "Correlations": {
+            "methods": {
+                "GetCorrelations": {
+                    "name": "GetCorrelations",
+                    "description": "Get correlations.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/correlations",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "CreateCorrelation": {
+                    "name": "CreateCorrelation",
+                    "description": "Create a correlation",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/correlations",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "UpdateCorrelationName": {
+                    "name": "UpdateCorrelationName",
+                    "description": "Update a correlation name.",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/rename",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "correlation_ID": {
+                            "default": "",
+                            "description": "correlation Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "GetCorrelation": {
+                    "name": "GetCorrelation",
+                    "description": "Get a correlation.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "correlation_ID": {
+                            "default": "",
+                            "description": "correlation Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "GetCorrelationCsv": {
+                    "name": "GetCorrelationCsv",
+                    "description": "Get a correlation CSV.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/export",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "correlation_ID": {
+                            "default": "",
+                            "description": "Correlation Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "DeleteCorrelation": {
+                    "name": "DeleteCorrelation",
+                    "description": "Delete a correlation.",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "correlation_ID": {
+                            "default": "",
+                            "description": "Correlation Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "UpdateCorrelationPreview": {
+                    "name": "UpdateCorrelationPreview",
+                    "description": "Update a correlation preview",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/correlations/{correlation_ID}/preview",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "Kpi": {
+            "methods": {
+                "getKpi": {
+                    "name": "getKpi Correlation",
+                    "description": "get Kpis from a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/kpis",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "kpisFamily": {
+                    "name": "kpisFamily",
+                    "description": "get all target or analysis kpi for rule builder and kpi page",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/kpis/family/{familyKpi_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getKpisForRuleBuilder": {
+                    "name": "getKpisForRuleBuilder",
+                    "description": "Get KPIs for Rule Builder",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/kpis/rb",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "addKpi": {
+                    "name": "add Kpi",
+                    "description": "add Kpis from a project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/kpis",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "deleteKpi": {
+                    "name": "deleteKpi",
+                    "description": "delete kpi",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/kpis/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "updateKpi": {
+                    "name": "updateKpi",
+                    "description": "update kpi",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/kpis/update",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "getScoreByKpis": {
+                    "name": "getScoreByKpis",
+                    "description": "get scores group by KpiName",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/kpis/scores",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getKpisVariables": {
+                    "name": "getKpisVariable",
+                    "description": "getKpisVariables",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/kpis/variables",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "Color": {
+            "methods": {
+                "getProjectColorsList": {
+                    "name": "get Project Color sList",
+                    "description": "get Project Color sList",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/colors",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateColor": {
+                    "name": "update Color",
+                    "description": "update color",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/colors",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false
+                    }
+                },
+                "removeColor": {
+                    "name": "delete Color",
+                    "description": "delete color",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/colors/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false
+                    }
+                }
+            }
+        },
+        "Simple Lift": {
+            "methods": {
+                "NewSimpleLift": {
+                    "name": "New Simple Lift",
+                    "description": "New Simple Lift",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/tasks/new",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "task": {
+                            "type": "object",
+                            "location": "body",
+                            "properties": {
+                                "type": {
+                                    "title": "type",
+                                    "type": "string",
+                                    "default": "simplelift",
+                                    "description": "Do not modify this field"
+                                },
+                                "projectId": {
+                                    "title": "projectId",
+                                    "type": "string",
+                                    "description": "Project Id."
+                                },
+                                "datasetId": {
+                                    "title": "datasetId",
+                                    "type": "string",
+                                    "description": "Dataset Id."
+                                },
+                                "datasetName": {
+                                    "title": "datasetName",
+                                    "type": "string",
+                                    "description": "datasetName."
+                                },
+                                "params": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "title": "name",
+                                            "type": "string",
+                                            "description": "name"
+                                        },
+                                        "target": {
+                                            "title": "target",
+                                            "type": "string",
+                                            "description": "target"
+                                        },
+                                        "quantileOrder": {
+                                            "title": "quantileOrder",
+                                            "default": "10",
+                                            "type": "string",
+                                            "description": "quantileOrder"
+                                        },
+                                        "source": {
+                                            "title": "sourceFileName",
+                                            "type": "string",
+                                            "description": " dataset sourceFileName"
+                                        },
+                                        "separator": {
+                                            "title": "separator",
+                                            "type": "string",
+                                            "description": " dataset delimiter"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "newSimpleLiftName": {
+                    "name": "new SimpleLift Name",
+                    "description": "new SimpleLift Name",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/simplelifts/newSimpleLiftName",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "getSimpleLiftJsonGLOBAL": {
+                    "name": "Get global JSON file",
+                    "description": "Retrieve SimpleLift JSON file.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/simplelifts/{task_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "task_ID": {
+                            "default": "",
+                            "description": "task_ID.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getSimpleLiftJsonVARIABLE": {
+                    "name": "Get variable JSON file",
+                    "description": "Retrieve SimpleLift JSON file.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/simplelifts/{task_ID}/variable/{column_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "task_ID": {
+                            "default": "",
+                            "description": "task_ID.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "col": {
+                            "default": "",
+                            "description": "column number.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getSimpleLiftCsv": {
+                    "name": "Get CSV file",
+                    "description": "Retrieve SimpleLift CSV file.",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/simplelifts/{task_ID}/exportSimplelift",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "task_ID": {
+                            "default": "",
+                            "description": "task_ID.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getSimpleLift": {
+                    "name": "getSimpleLift",
+                    "description": "get simple lift",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/simplelifts/{simpleLift_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getSimpleLifts": {
+                    "name": "getSimpleLifts",
+                    "description": "get simple lifts",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/simplelifts",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "Map": {
+            "methods": {
+                "process": {
+                    "name": "Retrieve data for geo mapping",
+                    "description": "Retrieve data for geo mapping",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/mapping/{type}",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "TimeSeriesQuery": {
+            "methods": {
+                "timeSeriesQueryTags": {
+                    "name": "timeSeriesQueryTags",
+                    "description": "get tag of time series",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeriesQuery/tags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesQuery"
+                    ]
+                },
+                "timeSeriesQueryDatapoints": {
+                    "name": "timeSeriesQueryDatapoints",
+                    "description": "query timeSeriesDataPoints",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeriesQuery/datapoints",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesQuery"
+                    ]
+                },
+                "timeSeriesQueryAggregations": {
+                    "name": "timeSeriesQueryAggregations",
+                    "description": "get aggregations of time series",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeriesQuery/aggregations",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesQuery"
+                    ]
+                },
+                "timeSeriesAddDataset": {
+                    "name": "timeSeriesAddDataset",
+                    "description": "create a new dataset from timeSeriesDataPoints",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeriesQuery/newdataset",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesQuery"
+                    ]
+                }
+            }
+        },
+        "TimeSeriesViz": {
+            "methods": {
+                "listTimeSeriesViz": {
+                    "name": "listTimeSeriesViz",
+                    "description": "list time series viz of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/timeSeries/list",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesViz"
+                    ]
+                },
+                "createTimeSeriesViz": {
+                    "name": "createTimeSeriesViz",
+                    "description": "create time series viz of a project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeries/new",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesViz"
+                    ]
+                },
+                "updateTimeSeriesViz": {
+                    "name": "updateTimeSeriesViz",
+                    "description": "update time series viz of a project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeries/update",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesViz"
+                    ]
+                },
+                "deleteTimeSeriesViz": {
+                    "name": "deleteTimeSeriesViz",
+                    "description": "delete time series viz of a project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeries/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesViz"
+                    ]
+                }
+            }
+        },
+        "TimeSeriesAnalysis": {
+            "methods": {
+                "listTimeSeriesAnalysis": {
+                    "name": "listTimeSeriesAnalysis",
+                    "description": "list time series analysis of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/timeSeriesAnalysis/",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesAnalysis"
+                    ]
+                },
+                "createTimeSeriesAnalysis": {
+                    "name": "createTimeSeriesAnalysis",
+                    "description": "create time series analysis of a project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeriesAnalysis/",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesAnalysis"
+                    ]
+                },
+                "updateTimeSeriesAnalysis": {
+                    "name": "updateTimeSeriesAnalysis",
+                    "description": "update time series analysis of a project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeriesAnalysis/{analysis_ID}/update",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesAnalysis"
+                    ]
+                },
+                "deleteTimeSeriesAnalysis": {
+                    "name": "deleteTimeSeriesAnalysis",
+                    "description": "delete time series analysis of a project",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/timeSeriesAnalysis/{analysis_ID}/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesAnalysis"
+                    ]
+                },
+                "getTimeSeriesAnalysis": {
+                    "name": "getTimeSeriesAnalysis",
+                    "description": "Get one time series analysis of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/timeSeriesAnalysis/{analysis_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "timeSeriesAnalysis"
+                    ]
+                }
+            }
+        },
+        "RulesetViz": {
+            "methods": {
+                "deleteRulesetViz": {
+                    "name": "Delete Ruleset Viz",
+                    "description": "Delete a ruleset Viz",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/rulesetViz/{rulesetViz_ID}/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "rulesetviz"
+                    ]
+                },
+                "renameRulesetViz": {
+                    "name": "Rename Ruleset Viz",
+                    "description": "Rename a ruleset Viz",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/rulesetViz/{rulesetViz_ID}/rename",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "rulesetviz"
+                    ]
+                },
+                "getAllRulesetViz": {
+                    "name": "Get All Ruleset Viz",
+                    "description": "Get all a ruleset Viz of a Project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/rulesetViz",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "rulesetviz"
+                    ]
+                },
+                "getRuleSetViz": {
+                    "name": "get Ruleset Viz",
+                    "description": "get a ruleset Viz, given its id",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/rulesetViz/{rulesetViz_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "rulesetviz"
+                    ]
+                },
+                "exportRuleSetViz": {
+                    "name": "export Ruleset Viz",
+                    "description": "export a ruleset Viz, given its id",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/rulesetViz/{rulesetViz_ID}/export",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "rulesetviz"
+                    ]
+                },
+                "updateRulesetViz": {
+                    "name": "Update Ruleset Viz",
+                    "description": "Update a ruleset Viz",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/rulesetViz/{rulesetViz_ID}/update",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "rulesetviz"
+                    ]
+                },
+                "createSampleRulesetViz": {
+                    "name": "createSampleRulesetViz",
+                    "description": "createSampleRulesetViz",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/rulesetViz/sample",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "rulesetviz"
+                    ]
+                },
+                "createRulesetViz": {
+                    "name": "createRulesetViz",
+                    "description": "createRulesetViz",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/rulesetViz/create",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "rulesetviz"
+                    ]
+                }
+            }
+        },
+        "Rules": {
+            "methods": {
+                "ruleAsDataset": {
+                    "name": "ruleAsDataset",
+                    "description": "save rule as dataset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/ruleAsDataset",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "addRulesTags": {
+                    "name": "Add tags to rules",
+                    "description": "Add tags to rules",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/tags/addRulesTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "ruleIds": {
+                            "type": "array",
+                            "items": {
+                                "title": "Rules id",
+                                "default": "",
+                                "description": "Rules Ids which will be taged",
+                                "required": true,
+                                "type": "string"
+                            }
+                        },
+                        "taglist": {
+                            "type": "array",
+                            "items": {
+                                "title": "Tag",
+                                "default": "",
+                                "description": "Tag to add",
+                                "required": true,
+                                "type": "string"
+                            }
+                        },
+                        "kpis": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "title": "KPI",
+                                "properties": {
+                                    "kpiId": {
+                                        "type": "string",
+                                        "required": true,
+                                        "default": "",
+                                        "description": "KPI Id"
+                                    },
+                                    "kpiName": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "KPI Name"
+                                    },
+                                    "scoreType": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Score Type"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "addRule": {
+                    "name": "Add rule from Rule Builder",
+                    "description": "Add rule from Rule Builder",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/rules/addRule",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id of the rule",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id of the rule",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "rule": {
+                            "type": "object",
+                            "title": "rule",
+                            "location": "body",
+                            "properties": {
+                                "DataSetID": {
+                                    "title": "DataSetID",
+                                    "type": "string",
+                                    "required": true,
+                                    "default": "",
+                                    "description": "dataset Id"
+                                },
+                                "constraints": {
+                                    "type": "array",
+                                    "title": "constraints",
+                                    "description": "Constraints of the rule",
+                                    "items": {
+                                        "title": "constraint",
+                                        "default": "",
+                                        "description": "Constraint of the rule",
+                                        "required": true,
+                                        "type": "object",
+                                        "properties": {
+                                            "varName": {
+                                                "title": "varName",
+                                                "type": "string",
+                                                "required": true,
+                                                "default": "",
+                                                "description": "Variable Name"
+                                            },
+                                            "level": {
+                                                "title": "level",
+                                                "type": "string",
+                                                "default": "",
+                                                "description": "Modality of discret variable"
+                                            },
+                                            "min": {
+                                                "title": "min",
+                                                "type": "string",
+                                                "default": "",
+                                                "description": "Min value of continue variable"
+                                            },
+                                            "max": {
+                                                "title": "max",
+                                                "type": "string",
+                                                "default": "",
+                                                "description": "Max value of continue variable"
+                                            }
+                                        }
+                                    }
+                                },
+                                "scores": {
+                                    "title": "scores",
+                                    "type": "string",
+                                    "description": "Scores Values (Format {'kpiId1':value1,'kpiId2':value2,'kpiId3':value3......})"
+                                },
+                                "tags": {
+                                    "title": "Tags",
+                                    "type": "array",
+                                    "description": "Tags of the rule",
+                                    "items": {
+                                        "title": "Tag",
+                                        "default": "",
+                                        "description": "Tag to add",
+                                        "required": true,
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "getRulesTags": {
+                    "name": "Get Rule Tags by DatasetId",
+                    "description": "Get rule tags list of a dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/tags/getRulesTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getRulesTag": {
+                    "name": "Get Rule Tag By TagId",
+                    "description": "Get rule tag list of a specific tag",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/tags/{tag_ID}/getRulesTag",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "tags_ID": {
+                            "default": "",
+                            "description": "Tag Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getRulesTagsOfProject": {
+                    "name": "Get Rule Tag",
+                    "description": "Get rule tag list of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/tags/getRulesTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getLearningsOfProject": {
+                    "name": "Get learnings",
+                    "description": "Get learnings of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/learnings",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getRule": {
+                    "name": "Get Rule by ruleId",
+                    "description": "Get rule by ruleId",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/rules/{rule_ID}/getRule",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getRules": {
+                    "name": "Get Rules",
+                    "description": "Get rules for a given dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/rules/getrules",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "tagAllRules": {
+                    "name": "tagallRules",
+                    "description": "tag all rules",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/tags/addAllRulesTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "countRoules": {
+                    "name": "Get the number of Rules",
+                    "description": "Get the number of Rules for a given dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/rules/countrules",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "newMinimizeName": {
+                    "name": "newMinimizeName",
+                    "description": "newMinimizeName",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/tags/newMinimizeName",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "newLearningName ": {
+                    "name": "newLearningName ",
+                    "description": "new Learning Name",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/tags/newLearningName",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "removeLearning": {
+                    "name": "Remove tags of rules",
+                    "description": "Remove tags of rules",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/tags/removeRulesTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "ruleIds": {
+                            "type": "array",
+                            "items": {
+                                "title": "Rules id",
+                                "default": "",
+                                "description": "Rules Ids which will be changed, all the rules will be changed if id list is null",
+                                "required": false,
+                                "type": "string"
+                            }
+                        },
+                        "ruleTags": {
+                            "type": "array",
+                            "items": {
+                                "title": "Tag",
+                                "default": "",
+                                "description": "Tag to remove",
+                                "required": true,
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "removeRuleset": {
+                    "name": "Remove a learning",
+                    "description": "Remove a learning",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/learning/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "applyRule": {
+                    "name": "Apply a Rule",
+                    "description": "Apply a Rule",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/rules/applyRule",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "constraints": {
+                            "type": "array",
+                            "title": "constraints",
+                            "description": "Constraints of the rule",
+                            "items": {
+                                "title": "constraint",
+                                "default": "",
+                                "description": "Constraint of the rule",
+                                "required": true,
+                                "type": "object",
+                                "properties": {
+                                    "varName": {
+                                        "title": "varName",
+                                        "type": "string",
+                                        "required": true,
+                                        "default": "",
+                                        "description": "Variable Name"
+                                    },
+                                    "level": {
+                                        "title": "level",
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Modality of discret variable"
+                                    },
+                                    "min": {
+                                        "title": "min",
+                                        "type": "number",
+                                        "default": "",
+                                        "required": false,
+                                        "description": "Min value of continue variable"
+                                    },
+                                    "max": {
+                                        "title": "max",
+                                        "type": "number",
+                                        "default": "",
+                                        "required": false,
+                                        "description": "Max value of continue variable"
+                                    }
+                                }
+                            }
+                        },
+                        "kpiIds": {
+                            "type": "string",
+                            "location": "body",
+                            "title": "KPI",
+                            "default": "",
+                            "description": "Kpi to calcul(Format {'kpiId1':0,'kpiId2':0,'kpiId3':0......})",
+                            "required": true
+                        }
+                    }
+                },
+                "updateRulesTags": {
+                    "name": "Update tags of rules",
+                    "description": "Update tags of rules",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/tags/updateRulesTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id of the rules",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "ruleIds": {
+                            "type": "array",
+                            "items": {
+                                "title": "Rules id",
+                                "default": "",
+                                "description": "Rules Ids to update",
+                                "required": true,
+                                "type": "string"
+                            }
+                        },
+                        "tagsToAdd": {
+                            "type": "array",
+                            "items": {
+                                "title": "Tag",
+                                "default": "",
+                                "description": "Tag to add",
+                                "required": true,
+                                "type": "string"
+                            }
+                        },
+                        "tagsToDelete": {
+                            "type": "array",
+                            "items": {
+                                "title": "Tag",
+                                "default": "",
+                                "description": "Tag to delete",
+                                "required": true,
+                                "type": "string"
+                            }
+                        },
+                        "kpis": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "title": "KPI",
+                                "properties": {
+                                    "kpiId": {
+                                        "type": "string",
+                                        "required": true,
+                                        "default": "",
+                                        "description": "KPI Id"
+                                    },
+                                    "kpiName": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "KPI Name"
+                                    },
+                                    "scoreType": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Score Type"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Query": {
+            "methods": {
+                "getQuery": {
+                    "name": "Get Query by query name",
+                    "description": "Get Query by query name",
+                    "httpMethod": "GET",
+                    "path": "/query/{project_ID}/{query_name}/getQuery",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id of the query",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "query_name": {
+                            "default": "",
+                            "description": "query name",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getQueries": {
+                    "name": "Get queries of a project",
+                    "description": "Get queries of a project",
+                    "httpMethod": "GET",
+                    "path": "/query/{project_ID}/getQueries",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id of the query",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteQuery": {
+                    "name": " Delete query",
+                    "description": "Delete query",
+                    "httpMethod": "POST",
+                    "path": "/query/{project_ID}/{dataset_ID}/{query_name}/deleteQuery",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "query_name": {
+                            "default": "",
+                            "description": "Query name",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "System": {
+            "methods": {
+                "features": {
+                    "name": "features",
+                    "description": "List of all feature present in conf",
+                    "httpMethod": "GET",
+                    "path": "/system/features",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                },
+                "personalApps": {
+                    "name": "personalApps",
+                    "description": "List of all personal apps present in conf",
+                    "httpMethod": "GET",
+                    "path": "/system/personalApps",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "products": {
+                    "name": "products",
+                    "description": "List of all available products",
+                    "httpMethod": "GET",
+                    "path": "/system/products",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                },
+                "about": {
+                    "name": "About",
+                    "description": "About HyperCube",
+                    "httpMethod": "GET",
+                    "path": "/system/about",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                },
+                "menu": {
+                    "name": "Menu",
+                    "description": "Product Menu",
+                    "httpMethod": "GET",
+                    "path": "/system/menu",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                },
+                "userAllowedResource": {
+                    "name": "userAllowedResource",
+                    "description": "User Allowed Resource",
+                    "httpMethod": "GET",
+                    "path": "/system/userAllowedResource",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": true,
+                        "unauthorize": true
+                    }
+                }
+            }
+        },
+        "DocApi": {
+            "methods": {
+                "docApi": {
+                    "name": "docApi",
+                    "description": "Documentaion of the HyperCubeApi",
+                    "httpMethod": "GET",
+                    "path": "/doc",
+                    "features": [
+                        "docApi"
+                    ],
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "docApihypercubeApi": {
+                    "name": "docApihypercubeApi",
+                    "description": "Documentaion HyperCubeApi.json",
+                    "httpMethod": "GET",
+                    "path": "/doc/hypercubeApi.json",
+                    "features": [
+                        "docApi"
+                    ],
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "docApiProcessReq": {
+                    "name": "docApiProcessReq",
+                    "description": "Documentaion Process Request",
+                    "httpMethod": "POST",
+                    "path": "/doc/processReq",
+                    "features": [
+                        "docApi"
+                    ],
+                    "role": {
+                        "user": false,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "Variable": {
+            "methods": {
+                "bins": {
+                    "name": "Bins",
+                    "description": "Get bins of a continuous variable",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/bin/{var_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "var_ID": {
+                            "default": "",
+                            "description": "Variable Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "variableTags": {
+                    "name": "variableTagsBins",
+                    "description": "Get tags of variabe",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/tags/variablesTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getVariable": {
+                    "name": "getVariable",
+                    "description": "Get variables of a dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/variables",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getVariablesAndTags": {
+                    "name": "getVariableAndTags",
+                    "description": "Get variables and tags of a dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/variablesAndTags",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getModalities": {
+                    "name": "getModalities",
+                    "description": "Get Modalities of a variable from reshaped dataset and origin dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/modalities",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "metatype": {
+                    "name": "metatype",
+                    "description": "Get metatype of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/tags/metatype",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "addVariableValidation": {
+                    "name": "addVariableValidation",
+                    "description": "add variable validation",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/variables/validation",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "getVariableValidation": {
+                    "name": "getVariableValidation",
+                    "description": "get variable validations",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/variables/validation",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "removeVariableValidation": {
+                    "name": "removeVariableValidation",
+                    "description": "remove variable validation",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/variables/validation/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "Visualization": {
+            "methods": {
+                "list": {
+                    "name": "List",
+                    "description": "List existing visualizations of a dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/visualizations",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getVisualisation": {
+                    "name": "getVisualisation",
+                    "description": "Get an existing visualisation object",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/visualizations/{visualization_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "visualization_ID": {
+                            "default": "",
+                            "description": "Visualization Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "create": {
+                    "name": "Create",
+                    "description": "Create a new visualisation",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/visualizations",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "createMany": {
+                    "name": "CreateMany",
+                    "description": "Create many visualizations",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/visualizations/createMany",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "update": {
+                    "name": "Update",
+                    "description": "Update an existing visualisation",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/visualizations/{visualization_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "visualization_ID": {
+                            "default": "",
+                            "description": "Visualization Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "Rename": {
+                    "name": "Rename",
+                    "description": "rename an existing visualization",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/visualizations/{visualization_ID}/rename",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "visualization_ID": {
+                            "default": "",
+                            "description": "Visualization Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "delete": {
+                    "name": "Delete",
+                    "description": "Delete an existing visualisation",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/visualizations/{visualization_ID}/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "visualization_ID": {
+                            "default": "",
+                            "description": "Visualization Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getProjectVisualisation": {
+                    "name": "getProjectVisualisation",
+                    "description": "Get an existing visualisation object",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/visualizations/{visualization_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "visualization_ID": {
+                            "default": "",
+                            "description": "Visualization Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "Task": {
+            "methods": {
+                "task": {
+                    "name": "task",
+                    "description": "Task",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/tasks",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "createTask": {
+                    "name": "create task",
+                    "description": "New Task",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/tasks/new",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteTask": {
+                    "name": "deleteTask",
+                    "description": "Task",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/tasks/{task_ID}/delete",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "_datasetId": {
+                            "default": "",
+                            "description": "Dataset Identifier",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "_Id": {
+                            "default": "",
+                            "description": "Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "type": {
+                            "default": "",
+                            "description": "type of the task",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "stopService": {
+                    "name": "stopService",
+                    "description": "stopService",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/tasks/stopService",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "pid": {
+                            "default": "",
+                            "description": "id of the parameter",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "Text Processing": {
+            "methods": {
+                "extract": {
+                    "name": "Extract Wordset",
+                    "description": "Extract new wordset from a dataset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/nlp/extract",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false
+                    }
+                },
+                "createWordset": {
+                    "name": "Create Wordset",
+                    "description": "Create Wordset from scratch",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/nlp/wordset/create",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false
+                    }
+                },
+                "enrich": {
+                    "name": "Enrich Dataset From Wordset",
+                    "description": "Enrich Dataset from Wordset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/nlp/enrich",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false
+                    }
+                },
+                "listWordset": {
+                    "name": "List Wordsets",
+                    "description": "List all wordsets of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/nlp/wordsets",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getWordset": {
+                    "name": "get Wordset",
+                    "description": "get a specific wordset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/nlp/wordset/{wordset_ID}",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "deleteWordset": {
+                    "name": "Delete Wordset",
+                    "description": "Delete a wordset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/nlp/wordset/{wordset_ID}/delete",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false
+                    }
+                },
+                "updateWordset": {
+                    "name": "update Wordset",
+                    "description": "update a specific wordset",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/nlp/wordset/{dataset_ID}/update",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false
+                    }
+                },
+                "createWordsetViz": {
+                    "name": "Create Wordset Visiaulization",
+                    "description": "Create a wordset visualization",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/wordsetsViz/create",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false
+                    }
+                },
+                "deleteWordsetVisualization": {
+                    "name": "delete Wordset Visualization",
+                    "description": "delete a wordset visualization",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/wordsetsViz/{wordsetViz_ID}/delete",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false
+                    }
+                },
+                "listWordsetViz": {
+                    "name": "Get wordsets Visualization",
+                    "description": "Get all Wordset Visualization of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/wordsetsViz",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "getWordsetViz": {
+                    "name": "Get wordset visualization",
+                    "description": "get a specific wordset visualization",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/wordsetsViz/{wordsetViz_ID}",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "updateWordsetViz": {
+                    "name": "update Wordset Visualization",
+                    "description": "update a wordset visualization",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/wordsetsViz/{wordsetViz_ID}/update",
+                    "features": [
+                        "selectEnrich"
+                    ],
+                    "role": {
+                        "user": true,
+                        "admin": false
+                    }
+                }
+            }
+        },
+        "Prediction": {
+            "methods": {
+                "getModel": {
+                    "name": "getModel",
+                    "description": "get a specific model",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/models/{model_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "model_ID": {
+                            "default": "",
+                            "description": "Model Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "features": [
+                        "gridSearch"
+                    ]
+                },
+                "getModels": {
+                    "name": "getModels",
+                    "description": "get a list of model",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/models",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "features": [
+                        "gridSearch"
+                    ]
+                },
+                "createModel": {
+                    "name": "createModel",
+                    "description": "create a model",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/models/create",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "features": [
+                        "gridSearch"
+                    ]
+                },
+                "zip zpark": {
+                    "name": "zip zpark",
+                    "description": "Zip the result folder created by spark",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/models/{prediction_ID}/zipSpark",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "prediction_ID": {
+                            "default": "",
+                            "description": "Prediction Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "download spark": {
+                    "name": "download spark",
+                    "description": "Export the zip file",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/models/{prediction_ID}/downloadSpark",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "prediction_ID": {
+                            "default": "",
+                            "description": "Prediction Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportScikit": {
+                    "name": "Export scikit",
+                    "description": "Export model created by scikit learn",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/models/{prediction_ID}/export",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "prediction_ID": {
+                            "default": "",
+                            "description": "Prediction Id.",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "newModelName": {
+                    "name": "newModelName",
+                    "description": "Get newModelName",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/tags/newModelName",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "confusionMatrix": {
+                    "name": "getConfusionMatrix",
+                    "description": "Get confusion matrix json file for a model",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/models/{model_ID}/confusionMatrix",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "modelRuleSet": {
+                    "name": "modelRuleSet",
+                    "description": "Get modelRuleSet",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/models/{model_ID}/modelRuleset",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "rename": {
+                    "name": "renameModel",
+                    "description": "Rename model",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/models/{model_ID}/rename",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "model_ID": {
+                            "default": "",
+                            "description": "Model Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportScores": {
+                    "name": "exportScores",
+                    "description": "export model scores",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/models/{model_ID}/exportScores",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "publishModel": {
+                    "name": "publishModel",
+                    "description": "publish a model",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/models/{model_ID}/publish",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "exportScoreCSV": {
+                    "name": "exportScoreCSV",
+                    "description": "export model scores",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/models/{model_ID}/exportScores",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "export": {
+                    "name": "export",
+                    "description": "export Scikit-learn model",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/models/{model_ID}/export",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "export": {
+                    "name": "export",
+                    "description": "export Scikit-learn model",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/models/{model_ID}/export",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "exportRules": {
+                    "name": "exportRules",
+                    "description": "export rules",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/models/{model_ID}/exportRules",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "exportPreprocessedData": {
+                    "name": "exportPreprocessedData",
+                    "description": "export preprocessed data",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/models/{model_ID}/exportPreprocessedData",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "exportRulesDataset": {
+                    "name": "exportRulesDataset",
+                    "description": "export rules dataset",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/rules/exportRules",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "Exports": {
+            "methods": {
+                "ExportModelScores": {
+                    "name": "export",
+                    "description": "export",
+                    "httpMethod": "GET",
+                    "path": "/exports/{file_name}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "Dashboards": {
+            "methods": {
+                "getDashboards": {
+                    "name": "getDashboards",
+                    "description": "Get Dashboards",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/dashboards",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getDashboard": {
+                    "name": "getDashboard",
+                    "description": "Get Dashboard",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/dashboards/{dashboard_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dashboard_ID": {
+                            "default": "",
+                            "description": "Dashboard Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "addDashboard": {
+                    "name": "addDashboard",
+                    "description": "Add Dashboard",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/dashboards",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "name": {
+                            "default": "",
+                            "description": "name of the dashboard",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "template_ID": {
+                            "default": "",
+                            "description": "ID of the dashboard template to use",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": {
+                            "default": "",
+                            "description": "Description of the project",
+                            "location": "path",
+                            "required": false,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateDashboard": {
+                    "name": "updateDashboard",
+                    "description": "Update Dashboard",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/dashboards/{dashboard_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dashboard_ID": {
+                            "default": "",
+                            "description": "Dashboard Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteDashboard": {
+                    "name": "deleteDashboard",
+                    "description": "Delete Dashboard",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/dashboards/{dashboard_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dashboard_ID": {
+                            "default": "",
+                            "description": "Dashboard Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getProjectDashboards": {
+                    "name": "getProjectDashboards",
+                    "description": "Get Dashboards",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/dashboards",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getProjectDashboard": {
+                    "name": "getProjectDashboard",
+                    "description": "Get Dashboard",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/dashboards/{dashboard_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dashboard_ID": {
+                            "default": "",
+                            "description": "Dashboard Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "addProjectDashboard": {
+                    "name": "addProjectDashboard",
+                    "description": "Add Dashboard",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/dashboards",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "name": {
+                            "default": "",
+                            "description": "name of the dashboard",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "template_ID": {
+                            "default": "",
+                            "description": "ID of the dashboard template to use",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": {
+                            "default": "",
+                            "description": "Description of the project",
+                            "location": "path",
+                            "required": false,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateProjectDashboard": {
+                    "name": "updateProjectDashboard",
+                    "description": "Update Dashboard",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/dashboards/{dashboard_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dashboard_ID": {
+                            "default": "",
+                            "description": "Dashboard Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteProjectDashboard": {
+                    "name": "deleteProjectDashboard",
+                    "description": "Delete Dashboard",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/dashboards/{dashboard_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dashboard_ID": {
+                            "default": "",
+                            "description": "Dashboard Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "workalendar": {
+            "methods": {
+                "getWorkalendarCountries": {
+                    "name": "getWorkalendarCountries",
+                    "description": "retrieve a list of countries handled by workalendar",
+                    "httpMethod": "GET",
+                    "path": "/workalendar/countries",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "notebooks": {
+            "methods": {
+                "getNotebooks": {
+                    "name": "getNotebooks",
+                    "description": "get notebooks",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/notebooks",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "notebooks"
+                    ]
+                },
+                "startNotebookServer": {
+                    "name": "startNotebookServer",
+                    "description": "start notebook server",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/notebookServer/start",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "notebooks"
+                    ]
+                },
+                "createNotebook": {
+                    "name": "createNotebook",
+                    "description": "createNotebook",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/notebooks/{notebook_name}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "notebooks"
+                    ]
+                },
+                "stoptNotebookServer": {
+                    "name": "stopNotebookServer",
+                    "description": "stop notebook server",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/notebookServer/stop",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "notebooks"
+                    ]
+                },
+                "shutDownNotebook": {
+                    "name": "shutDownNotebook",
+                    "description": "shutdown a notebook",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/notebooks/{notebook_name}/stop",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "notebooks"
+                    ]
+                },
+                "deleteNoteBook": {
+                    "name": "deleteNoteBook",
+                    "description": "delete a notebook",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/notebooks/{notebook_name}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "notebooks"
+                    ]
+                },
+                "renameNotebook": {
+                    "name": "renameNotebook",
+                    "description": "rename a notebook",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/notebooks/{notebook_name}/rename/{new_name}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "notebooks"
+                    ]
+                },
+                "copyNotebook": {
+                    "name": "copyNotebook",
+                    "description": "copy a notebook",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/notebooks/{notebook_name}/copy",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "notebooks"
+                    ]
+                }
+            }
+        },
+        "hyperEngines": {
+            "methods": {
+                "hyperenginesListUp": {
+                    "name": "hyperenginesListUp",
+                    "description": "list all hyperengines up",
+                    "httpMethod": "GET",
+                    "path": "/hyperEngine/list",
+                    "role": {
+                        "admin": true,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "clusterInformation": {
+                    "name": "clusterInformation",
+                    "description": "get ecs cluster information",
+                    "httpMethod": "GET",
+                    "path": "/hyperEngine/cluster",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                },
+                "mongoLatency": {
+                    "name": "mongoLatency",
+                    "description": "get mongoLatency",
+                    "httpMethod": "GET",
+                    "path": "/hyperEngine/mongoLatency",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "nbInstances": {
+                    "name": "nbInstances",
+                    "description": "get number of HyperEngines Instances",
+                    "httpMethod": "GET",
+                    "path": "/hyperEngine/nbInstances",
+                    "role": {
+                        "admin": true,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "monitoring": {
+            "methods": {
+                "listWorksOfAProject": {
+                    "name": "listWorksOfAProject",
+                    "description": "list all works of a project",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/works",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "killWork": {
+                    "name": "killWork",
+                    "description": "kill a work",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/works/{work_ID}/stop",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "worksDetails": {
+                    "name": "worksDetails",
+                    "description": "works details",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/works/{work_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "hyperWorkersList": {
+                    "name": "hyperWorkersList",
+                    "description": "list all hyperworker up",
+                    "httpMethod": "GET",
+                    "path": "/monitoring/hyperWorkerList",
+                    "role": {
+                        "admin": true,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "processList": {
+                    "name": "processList",
+                    "description": "list all process up",
+                    "httpMethod": "GET",
+                    "path": "/monitoring/processList",
+                    "role": {
+                        "admin": true,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "lastActiveUsers": {
+                    "name": "lastActiveUsers",
+                    "description": "last Active Users",
+                    "httpMethod": "GET",
+                    "path": "/monitoring/lastActiveUsers",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "instanceList": {
+                    "name": "instanceList",
+                    "description": "list all instances",
+                    "httpMethod": "GET",
+                    "path": "/monitoring/instances",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "instanceSpawn": {
+                    "name": "instanceSpawn",
+                    "description": "spawn an instance",
+                    "httpMethod": "POST",
+                    "path": "/monitoring/instances/spawn",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "killWorker": {
+                    "name": "killWorker",
+                    "description": "kill a worker",
+                    "httpMethod": "POST",
+                    "path": "/monitoring/workers/{worker_ID}/kill",
+                    "role": {
+                        "admin": true,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "metrics": {
+                    "name": "metrics",
+                    "description": "Get app's metrics",
+                    "httpMethod": "GET",
+                    "path": "/monitoring/metrics",
+                    "role": {
+                        "admin": true,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "3rdParties": {
+            "methods": {
+                "get3rdPartiesSettings": {
+                    "name": "get3rdPartiesSettings",
+                    "description": "Get 3rd parties applications settings",
+                    "httpMethod": "GET",
+                    "path": "/3rdparties",
+                    "role": {
+                        "admin": true,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "realTimeSocket": {
+            "methods": {
+                "getRealTimeSettings": {
+                    "name": "getRealTimeSettings",
+                    "description": "Get realtime socket settings",
+                    "httpMethod": "GET",
+                    "path": "/realTimeSocket",
+                    "role": {
+                        "admin": true,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "analytics": {
+            "methods": {
+                "newPageView": {
+                    "name": "newPageView",
+                    "description": "Saves a new page view",
+                    "httpMethod": "POST",
+                    "path": "/analytics/pageView",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "analytics"
+                    ]
+                }
+            }
+        },
+        "optimProcess": {
+            "methods": {
+                "getSandboxDataForControlChart": {
+                    "name": "getSandboxDataForControlChart",
+                    "description": "Get the sandbox data for a control chart",
+                    "httpMethod": "GET",
+                    "path": "/optimProcess/projects/{project_ID}/controlCharts/{controlChart_ID}/data",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_control_chart"
+                    ]
+                },
+                "getAllControlChart": {
+                    "name": "getAllControlChart",
+                    "description": "Get all control charts",
+                    "httpMethod": "GET",
+                    "path": "/optimProcess/projects/{project_ID}/controlCharts",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_control_chart"
+                    ]
+                },
+                "getOneControlChart": {
+                    "name": "getOneControlChart",
+                    "description": "Get one control chart",
+                    "httpMethod": "GET",
+                    "path": "/optimProcess/projects/{project_ID}/controlCharts/{controlChart_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_control_chart"
+                    ]
+                },
+                "postControlChart": {
+                    "name": "postControlChart",
+                    "description": "Post a new control chart",
+                    "httpMethod": "POST",
+                    "path": "/optimProcess/projects/{project_ID}/controlCharts",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_control_chart"
+                    ]
+                },
+                "updateControlChart": {
+                    "name": "updateControlChart",
+                    "description": "Update a control chart",
+                    "httpMethod": "POST",
+                    "path": "/optimProcess/projects/{project_ID}/controlCharts/{controlChart_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_control_chart"
+                    ]
+                },
+                "publishControlChartToEtl": {
+                    "name": "PublishControlChartToEtl",
+                    "description": "Publish a control chart to the ETL",
+                    "httpMethod": "POST",
+                    "path": "/optimProcess/projects/{project_ID}/controlCharts/{controlChart_ID}/etlpublish",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_control_chart"
+                    ]
+                },
+                "getOPDashboards": {
+                    "name": "getOPDashboards",
+                    "description": "Get your dashboards",
+                    "httpMethod": "GET",
+                    "path": "/optimProcess/projects/{project_ID}/dashboards",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_dashboard"
+                    ]
+                },
+                "postDashboard": {
+                    "name": "postDashboard",
+                    "description": "Create a dashboard for a project",
+                    "httpMethod": "POST",
+                    "path": "/optimProcess/projects/{project_ID}/dashboards",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_dashboard"
+                    ]
+                },
+                "postGraph": {
+                    "name": "postGraph",
+                    "description": "Add a graph to a dashboard",
+                    "httpMethod": "POST",
+                    "path": "/optimProcess/projects/{project_ID}/dashboards/{dashboard_ID}/graphs",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_dashboard"
+                    ]
+                },
+                "deleteGraph": {
+                    "name": "deleteGraph",
+                    "description": "Remove a graph from a dashboard",
+                    "httpMethod": "POST",
+                    "path": "/optimProcess/projects/{project_ID}/dashboards/{dashboard_ID}/graphs/remove",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_dashboard"
+                    ]
+                },
+                "deleteOPDashboard": {
+                    "name": "deleteOPDashboard",
+                    "description": "Delete a dashboard for a project",
+                    "httpMethod": "POST",
+                    "path": "/optimProcess/projects/{project_ID}/dashboards/{dashboard_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "op_dashboard"
+                    ]
+                }
+            }
+        },
+        "scheduler-dashboard": {
+            "methods": {
+                "home": {
+                    "name": "home",
+                    "description": "Homepage",
+                    "httpMethod": "GET",
+                    "path": "/scheduler-dashboard",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "schedulerDashboard"
+                    ]
+                },
+                "scheduler-api": {
+                    "name": "scheduler-api",
+                    "description": "scheduler api",
+                    "httpMethod": "GET",
+                    "path": "/scheduler-dashboard/api",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "schedulerDashboard"
+                    ]
+                },
+                "scheduler-api-jobs-requeue": {
+                    "name": "scheduler-api-jobs-requeue",
+                    "description": "scheduler api",
+                    "httpMethod": "POST",
+                    "path": "/scheduler-dashboard/api/jobs/requeue",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "schedulerDashboard"
+                    ]
+                },
+                "scheduler-api-jobs-delete": {
+                    "name": "scheduler-api-jobs-delete",
+                    "description": "scheduler api",
+                    "httpMethod": "POST",
+                    "path": "/scheduler-dashboard/api/jobs/delete",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "schedulerDashboard"
+                    ]
+                },
+                "scheduler-api-jobs-create": {
+                    "name": "scheduler-api-jobs-create",
+                    "description": "scheduler api",
+                    "httpMethod": "POST",
+                    "path": "/scheduler-dashboard/api/jobs/create",
+                    "role": {
+                        "admin": true,
+                        "user": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    },
+                    "features": [
+                        "schedulerDashboard"
+                    ]
+                }
+            }
+        },
+        "tempData": {
+            "methods": {
+                "getTempData": {
+                    "name": "tempData",
+                    "description": "get temprorary data",
+                    "httpMethod": "GET",
+                    "path": "/tempData",
+                    "role": {
+                        "user": true,
+                        "admin": false,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "workflows": {
+            "methods": {
+                "getWorkflows": {
+                    "name": "getWorkflows",
+                    "description": "get Workflows",
+                    "httpMethod": "GET",
+                    "path": "/workflows",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "getWorkflow": {
+                    "name": "getWorkflow",
+                    "description": "get Workflow",
+                    "httpMethod": "GET",
+                    "path": "/workflows/{workflow_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "applyWorkflow": {
+                    "name": "applyWorkflow",
+                    "description": "apply Json workflow",
+                    "httpMethod": "POST",
+                    "path": "/workflows/apply",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "getWorks": {
+                    "name": "getWorks",
+                    "description": "get Works",
+                    "httpMethod": "GET",
+                    "path": "/workflows/works",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                },
+                "getWork": {
+                    "name": "getWork",
+                    "description": "get Work",
+                    "httpMethod": "GET",
+                    "path": "/workflows/works/{work_ID}",
+                    "role": {
+                        "user": true,
+                        "admin": true,
+                        "readOnly": false,
+                        "unauthorize": false
+                    }
+                }
+            }
+        },
+        "nitro": {
+            "methods": {
+                "getForecasts": {
+                    "name": "getForecasts",
+                    "description": "Get Forecasts",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getForecast": {
+                    "name": "getForecast",
+                    "description": "Get Forecast",
+                    "httpMethod": "GET",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "insertForecast": {
+                    "name": "insertForecast",
+                    "description": "Insert Forecast",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/add",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "date": {
+                            "description": "date to calculate the forecast",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "description of the forecast",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateForecast": {
+                    "name": "updateForecast",
+                    "description": "Update Forecast",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "date": {
+                            "description": "date to calculate the forecast",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "description of the forecast",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteForecast": {
+                    "name": "deleteForecast",
+                    "description": "Delete Forecast",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getForecastTunes": {
+                    "name": "getForecastTunes",
+                    "description": "Get Forecast Tunes",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getForecastTunesStats": {
+                    "name": "getForecastTunesStats",
+                    "description": "Get Forecast Tunes Stats",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/stats",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateForecastTunes": {
+                    "name": "updateForecastTunes",
+                    "description": "Update Forecast Tunes",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/update",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "providedCoefficient": {
+                            "description": "Adjusment Coefficient",
+                            "location": "body",
+                            "required": true,
+                            "type": "number"
+                        },
+                        "manualTune": {
+                            "description": "Manual Coefficient",
+                            "location": "body",
+                            "required": true,
+                            "type": "number"
+                        },
+                        "networkTune": {
+                            "description": "Network Coefficient",
+                            "location": "body",
+                            "required": true,
+                            "type": "number"
+                        }
+                    }
+                },
+                "exportReport": {
+                    "name": "exportReport",
+                    "description": "Export report of Forecast update from external file",
+                    "httpMethod": "GET",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/exportreport",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateForecastCoef": {
+                    "name": "updateForecastCoef",
+                    "description": "Import Forecast Coefficients (adjustment, network and manually proposed)",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/updatecoef",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getForecastTunesAggregateGeo": {
+                    "name": "getForecastTunesAggregateGeo",
+                    "description": "Get Forecast Tunes Aggregate by Geo",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/aggregate/geo",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getForecastTunesAggregateDepot": {
+                    "name": "getForecastTunesAggregateDepot",
+                    "description": "Get Forecast Tunes Aggregate by Depot",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/aggregate/depot",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportForecastTunes": {
+                    "name": "exportForecastTunes",
+                    "description": "Export Forecast Tunes",
+                    "httpMethod": "GET",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/export",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getForecastTunesMetadata": {
+                    "name": "getForecastTunesMetadata",
+                    "description": "Get Forecast Tunes metadata",
+                    "httpMethod": "GET",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/metadata",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getForecastTunesModalities": {
+                    "name": "getForecastTunesModalities",
+                    "description": "Get Forecast Tunes modalities",
+                    "httpMethod": "POST",
+                    "path": "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/modalities",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "forecast_ID": {
+                            "default": "",
+                            "description": "Forecast Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "alerts": {
+            "methods": {
+                "getAlerts": {
+                    "name": "getAlerts",
+                    "description": "Get Alerts",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "computeAlerts": {
+                    "name": "computeAlerts",
+                    "description": "Compute Alerts",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group/{alert_group_ID}/compute",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "alert_group_ID": {
+                            "default": "",
+                            "description": "Alert Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "ignoreAlerts": {
+                    "name": "ignoreAlerts",
+                    "description": "Ignore Alert",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group/{alert_group_ID}/ignore",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "alert_group_ID": {
+                            "default": "",
+                            "description": "Alert Group Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "resolveAlerts": {
+                    "name": "resolveAlerts",
+                    "description": "Resolve Alert",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group/{alert_group_ID}/resolve",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "alert_group_ID": {
+                            "default": "",
+                            "description": "Alert Group Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "proposeAlertsResolution": {
+                    "name": "proposeAlertsResolution",
+                    "description": "Propose Alerts Resolution",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/group/{alert_group_ID}/proposeResolution",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "alert_group_ID": {
+                            "default": "",
+                            "description": "alert group ID",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getAlert": {
+                    "name": "getAlert",
+                    "description": "get Alert",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "alert_ID": {
+                            "default": "",
+                            "description": "Alert Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "ignoreAlert": {
+                    "name": "ignoreAlert",
+                    "description": "Ignore Alert",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}/ignore",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "alert_ID": {
+                            "default": "",
+                            "description": "Alert Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "resolveAlert": {
+                    "name": "resolveAlert",
+                    "description": "Resolve Alert",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}/resolve",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "alert_ID": {
+                            "default": "",
+                            "description": "Alert Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "proposeAlertResolution": {
+                    "name": "proposeAlertResolution",
+                    "description": "Propose Alert Resolution",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/alerts/{alert_ID}/proposeResolution",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "alert_ID": {
+                            "default": "",
+                            "description": "Alert Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "SmartDataViz": {
+            "methods": {
+                "getSmartDataViz": {
+                    "name": "getSmartDataViz",
+                    "description": "Get SmartDataViz",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/smartDataViz/{smartDataViz_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "smartDataViz_ID": {
+                            "default": "",
+                            "description": "SmartDataViz Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "computeSmartDataViz": {
+                    "name": "computeSmartDataViz",
+                    "description": "Compute SmartDataViz",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/smartDataViz/",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getSmartDataVizs": {
+                    "name": "getSmartDataVizs",
+                    "description": "Get SmartDataVizs",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/smartDataViz/",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteSmartDataViz": {
+                    "name": "deleteSmartDataViz",
+                    "description": "Delete SmartDataViz",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/smartDataViz/{smartDataViz_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "smartDataViz_ID": {
+                            "default": "",
+                            "description": "SmartDataViz Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "Reports": {
+            "methods": {
+                "exportDatasetReports": {
+                    "name": "exportDatasetReports",
+                    "description": "Export a dataset report",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/reports",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportProjectReports": {
+                    "name": "exportProjectReports",
+                    "description": "Export a project report",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/reports",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "ProjectResources": {
+            "methods": {
+                "getProjectResource": {
+                    "name": "getProjectResource",
+                    "description": "Get a Project Resource",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/resources",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "DatasetResources": {
+            "methods": {
+                "getDatasetResource": {
+                    "name": "getDatasetResource",
+                    "description": "Get a Dataset Resource",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/resources",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "auxdata": {
+            "methods": {
+                "getProjectAuxData": {
+                    "name": "getProjectAuxData",
+                    "description": "Get Project Aux Data",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/auxdata",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "createAuxData": {
+                    "name": "createAuxData",
+                    "description": "Create Aux Data",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/auxdata",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getAuxData": {
+                    "name": "getAuxData",
+                    "description": "get Aux Data",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateAuxData": {
+                    "name": "updateAuxData",
+                    "description": "Update Aux Data",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteAuxData": {
+                    "name": "deleteAuxData",
+                    "description": "Delete Aux Data",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportAuxData": {
+                    "name": "exportAuxData",
+                    "description": "Export Aux Data",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/export",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "viewAuxData": {
+                    "name": "viewAuxData",
+                    "description": "View Aux Data",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/view",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "copyAuxData": {
+                    "name": "copyAuxData",
+                    "description": "Copy Aux Data",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/copy",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "listAuxDataElems": {
+                    "name": "listAuxDataElems",
+                    "description": "List Aux Data Elements",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/listelems",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getAuxDataMatrices": {
+                    "name": "getAuxDataMatrices",
+                    "description": "Get Aux Data Matrices",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/matrices",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportAuxDataMatrices": {
+                    "name": "exportAuxDataMatrices",
+                    "description": "Export Aux Data Matrice",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/exportMatrices/{work_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "work_ID": {
+                            "default": "",
+                            "description": "Work Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "importAuxDataMatrices": {
+                    "name": "importAuxDataMatrices",
+                    "description": "Import Aux Data Matrice",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/importMatrices",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateAuxDataMatrices": {
+                    "name": "updateAuxDataMatrices",
+                    "description": "Update Aux Data Matrices",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/auxdata/{auxdata_ID}/matrices",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "auxdata_ID": {
+                            "default": "",
+                            "description": "Aux Data Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "listAuxDataGroups": {
+                    "name": "listAuxDataGroups",
+                    "description": "List Aux Data Groups",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/auxdata/groups",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "validateAuxData": {
+                    "name": "validateAuxData",
+                    "description": "Validate Aux Data",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/auxdata/validate",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "body",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "joinDatasets": {
+            "methods": {
+                "joinDatasets": {
+                    "name": "joinDatasets",
+                    "description": "Join Datasets",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/join",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "compareDatasets": {
+                    "name": "compareDatasets",
+                    "description": "Compare Datasets",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/compare",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "datasetReshapes": {
+            "methods": {
+                "proposeAlterations": {
+                    "name": "proposeAlterations",
+                    "description": "Propose Alterations",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/reshapes/proposeAlterations",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getReshapes": {
+                    "name": "getReshapes",
+                    "description": "Get Reshapes",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/reshapes",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "createReshape": {
+                    "name": "createReshape",
+                    "description": "Create Reshape",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/reshapes",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "reshape_ID": {
+                            "default": "",
+                            "description": "Reshape Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getReshape": {
+                    "name": "getReshape",
+                    "description": "Get Reshape",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/reshapes/{reshape_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "reshape_ID": {
+                            "default": "",
+                            "description": "Reshape Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateReshape": {
+                    "name": "updateReshape",
+                    "description": "Update Reshape",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/reshapes/{reshape_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "reshape_ID": {
+                            "default": "",
+                            "description": "Reshape Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteReshape": {
+                    "name": "deleteReshape",
+                    "description": "Delete Reshape",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/reshapes/{reshape_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "reshape_ID": {
+                            "default": "",
+                            "description": "Reshape Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "inheritReshape": {
+                    "name": "inheritReshape",
+                    "description": "Inherit Reshape",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/reshapes/{reshape_ID}/inherit",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "reshape_ID": {
+                            "default": "",
+                            "description": "Reshape Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "publishReshapeToEtl": {
+                    "name": "publishReshapeToEtl",
+                    "description": "Publish a Reshape to the ETL",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/reshapes/{reshape_ID}/etlpublish",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "reshape_ID": {
+                            "default": "",
+                            "description": "Reshape Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getReshapeGroups": {
+                    "name": "getReshapeGroups",
+                    "description": "Get Reshape Groups",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/reshapes/{reshape_ID}/groups",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "reshape_ID": {
+                            "default": "",
+                            "description": "Reshape Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getReshapesGroups": {
+                    "name": "getReshapesGroups",
+                    "description": "Get Reshapes Groups",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/reshapes/groups",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "createReshapeGroup": {
+                    "name": "createReshapeGroup",
+                    "description": "Create Reshape Group",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/reshapes/groups",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getReshapeGroup": {
+                    "name": "getReshapeGroup",
+                    "description": "Get Reshape Group",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/reshapes/groups/{group_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "group_ID": {
+                            "default": "",
+                            "description": "Group Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "updateReshapeGroup": {
+                    "name": "updateReshapeGroup",
+                    "description": "Update Reshape Group",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/reshapes/groups/{group_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "group_ID": {
+                            "default": "",
+                            "description": "Group Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteReshapeGroup": {
+                    "name": "deleteReshapeGroup",
+                    "description": "Delete Reshape Group",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/reshapes/groups/{group_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "group_ID": {
+                            "default": "",
+                            "description": "Group Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "describeReshape": {
+                    "name": "describeReshape",
+                    "description": "Describe Reshape",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/reshapes/describe",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getReshapeDescription": {
+                    "name": "getReshapeDescription",
+                    "description": "Get Reshape Description",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/reshapes/describe",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "applyReshape": {
+                    "name": "applyReshape",
+                    "description": "Apply Reshape",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/reshapes/{reshape_ID}/apply",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "reshape_ID": {
+                            "default": "",
+                            "description": "Reshape Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "removeReshape": {
+                    "name": "removeReshape",
+                    "description": "Remove Reshape",
+                    "httpMethod": "POST",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/reshapes/remove",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "exportSteps": {
+                    "name": "exportsteps",
+                    "description": "Export Reshape Steps",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/datasets/{dataset_ID}/reshapes/exportsteps",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "dataset_ID": {
+                            "default": "",
+                            "description": "Dataset Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "swpMatchmaking": {
+            "methods": {
+                "getAgents": {
+                    "name": "getAgents",
+                    "description": "Get Agents",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/redeployments/{work_ID}/agents",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "work_ID": {
+                            "default": "",
+                            "description": "Work Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getOptimizationDetail": {
+                    "name": "getOptimizationDetail",
+                    "description": "Get optimizationDetail",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/redeployments/{work_ID}/optimizationDetail",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "work_ID": {
+                            "default": "",
+                            "description": "Work Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getMatches": {
+                    "name": "getMatches",
+                    "description": "Get Matches",
+                    "httpMethod": "GET",
+                    "path": "/projects/{project_ID}/redeployments/{work_ID}/agents/{agent_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "parameters": {
+                        "project_ID": {
+                            "default": "",
+                            "description": "Project Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "work_ID": {
+                            "default": "",
+                            "description": "Work Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        "agent_ID": {
+                            "default": "",
+                            "description": "Work Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "iotEtlApi": {
+            "methods": {
+                "getAllStreams": {
+                    "name": "getAllStreams",
+                    "description": "Get All Streams",
+                    "httpMethod": "GET",
+                    "path": "/etl/streams",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "iotEtl"
+                    ]
+                },
+                "createStream": {
+                    "name": "createStream",
+                    "description": "create a new stream",
+                    "httpMethod": "POST",
+                    "path": "/etl/streams",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "iotEtl"
+                    ]
+                },
+                "updateStream": {
+                    "name": "updateStream",
+                    "description": "update a stream",
+                    "httpMethod": "POST",
+                    "path": "/etl/streams/{stream_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "iotEtl"
+                    ],
+                    "parameters": {
+                        "stream_ID": {
+                            "default": "",
+                            "description": "Stream Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "deleteStream": {
+                    "name": "deleteStream",
+                    "description": "delete an existing stream",
+                    "httpMethod": "POST",
+                    "path": "/etl/streams/{stream_ID}/delete",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "iotEtl"
+                    ],
+                    "parameters": {
+                        "stream_ID": {
+                            "default": "",
+                            "description": "Stream Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                },
+                "getStream": {
+                    "name": "getStream",
+                    "description": "get a stream details",
+                    "httpMethod": "GET",
+                    "path": "/etl/streams/{stream_ID}",
+                    "role": {
+                        "admin": false,
+                        "user": true,
+                        "readOnly": true,
+                        "unauthorize": false
+                    },
+                    "feature": [
+                        "iotEtl"
+                    ],
+                    "parameters": {
+                        "stream_ID": {
+                            "default": "",
+                            "description": "Stream Id",
+                            "location": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 6.0.5

- Adding Route `getForecastTunesMetadata`
    - Available since HDP 4.2.2
    - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/metadata`

- Adding Route `getForecastTunesModalities`
    - Available since HDP 4.2.2
    - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/tunes/modalities`

### Build
https://eu-central-1.console.aws.amazon.com/codesuite/codebuild/projects/hyperapi_build/build/hyperapi_build:a3975c22-97c7-478f-8254-10fd639630d9/log?region=eu-central-1