### PR TITLE
[6.0.6]: Add new parameter to api call signature to get the raw response

### DIFF
--- a/HyperAPI/sessionClass.py
+++ b/HyperAPI/sessionClass.py
@@ -77,7 +77,7 @@ class Session:
     def refresh(self, username=None, password=None, token=None):
         self.__login(username, password, token)
 
-    def request(self, method, url, params=None, json=None, data=None, affinity=None, streaming=False):
+    def request(self, method, url, params=None, json=None, data=None, affinity=None, streaming=False, raw_response=False):
         """Make a request to rest API and return response as json."""
         params = params or {}
         json = json or {}
@@ -104,6 +104,9 @@ class Session:
             resp = self.session.request(method, url, params=params, json=json, data=multi_data, headers=headers)
         else:
             resp = self.session.request(method, url, params=params, json=json, data=data, headers=headers)
+
+        if raw_response:
+            return resp
 
         if not resp.ok:
             raise requests.exceptions.HTTPError(

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## Version 6
 
+### 6.0.6
+
+- Adding new parameter to api call signature to get the raw response
+    - api.System.about(raw_response=True)
+
 ### 6.0.5
 
 - Adding Route `getForecastTunesMetadata`


### PR DESCRIPTION
### 6.0.6

- Add new parameter to api call signature to get the raw response
    - api.System.about(raw_response=True)

### Build
https://eu-central-1.console.aws.amazon.com/codesuite/codebuild/projects/hyperapi_build/build/hyperapi_build:a3975c22-97c7-478f-8254-10fd639630d9/log?region=eu-central-1