### PR TITLE
[6.0.8] Put extract suffix method into general class

### DIFF
--- a/HyperAPI/hyper_api/model.py
+++ b/HyperAPI/hyper_api/model.py
@@ -799,6 +799,10 @@ class Model(Base):
             self._is_deleted = True
         return self
 
+    def __extract_exportfile_suffix(self, file_path):
+        return file_path.split("_")[len(file_path.split("_"))-1]
+
+
 
 class ClassifierModel(Model):
     """
@@ -870,9 +874,6 @@ class ClassifierModel(Model):
         df = pd.read_csv(StringIO(url.decode('utf-8')))
         applied_model.delete()
         return df
-
-    def __extract_exportfile_suffix(self, file_path):
-        return file_path.split("_")[len(file_path.split("_"))-1]
 
     @Helper.try_catch
     def export_scores(self, path, variables=None):


### PR DESCRIPTION
Erratum: the method created to get the file suffix for exporting models was into the Classifier class and not into the most general Model class, causing Regressors to fail. 