### PR TITLE
[6.0.9] Add getAuxDataModalities route

### DIFF
--- a/HyperAPI/hdp_api/routes/auxdata.py
+++ b/HyperAPI/hdp_api/routes/auxdata.py
@@ -140,3 +140,11 @@ class AuxData(Resource):
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
         }
+
+    class _getAuxDataModalities(Route):
+        name = "getAuxDataModalities"
+        httpMethod = Route.GET
+        path = "/projects/{project_ID}/auxdata/modalities/query"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+        }

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## Version 6
 
+### 6.0.9
+
+- Adding Route `getAuxDataModalities`
+    - Available since HDP 4.2.4
+    - GET `/projects/{project_ID}/auxdata/modalities/query`
+
 ### 6.0.8
 
 - Fix export models


### PR DESCRIPTION
- Adding Route `getAuxDataModalities`
    - Available since HDP 4.2.4
    - GET `/projects/{project_ID}/auxdata/modalities/query`