### PR TITLE
[6.0.10] Add auxdata update route

### DIFF
--- a/HyperAPI/hdp_api/routes/auxdata.py
+++ b/HyperAPI/hdp_api/routes/auxdata.py
@@ -158,3 +158,12 @@ class AuxData(Resource):
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
         }
+
+    class _updateAuxDataModalities(Route):
+        name = "updateAuxDataModalities"
+        httpMethod = Route.POST
+        available_since = "4.2.4"
+        path = "/projects/{project_ID}/auxdata/modalities/update"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+        }

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## Version 6
 
+### 6.0.10
+
+- Adding Route `updateAuxDataModalities`
+    - Available since HDP 4.2.4
+    - GET `/projects/{project_ID}/auxdata/modalities/update`
+  
 ### 6.0.9
 
 - Adding Route `getAuxDataModalities`


### PR DESCRIPTION
Added the following route, to update auxdata with new values:

   ```
class _updateAuxDataModalities(Route):
        name = "updateAuxDataModalities"
        httpMethod = Route.POST
        available_since = "4.2.4"
        path = "/projects/{project_ID}/auxdata/modalities/update"
        _path_keys = {
            'project_ID': Route.VALIDATOR_OBJECTID,
        }
```

Link to the build:
https://eu-central-1.console.aws.amazon.com/codesuite/codebuild/projects/hyperapi_test/build/hyperapi_test%3Aa4cc8424-8bc8-4310-b8d5-131a4c05f4f7/log