### PR TITLE
[7.0.3] - [NITRO]: change the getForecastTunesMetadata for getForecastMetadata 

### DIFF
--- a/HyperAPI/hdp_api/routes/nitro.py
+++ b/HyperAPI/hdp_api/routes/nitro.py
@@ -202,12 +202,23 @@ class Nitro(Resource):
     class _getForecastMetadata(Route):
         name = "getForecastMetadata"
         available_since = '4.2.3'
+        removed_since = '4.2.8'
         httpMethod = Route.GET
         path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/metadata"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'dataset_ID': Route.VALIDATOR_OBJECTID
         }
+
+    class _getForecastIdMetadata(Route):
+        name = "getForecastIdMetadata"
+        available_since = '4.2.8'
+        httpMethod = Route.GET
+        path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/metadata"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID
+        }        
 
     class _getForecastTunesModalities(Route):
         name = "getForecastTunesModalities"

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,17 @@
 # HyperAPI Changelog
 
 ## Version 7
+
+### 7.0.3
+
+- Adding Route `getForecastIdMetadata`
+    - Available since HDP 4.2.8
+    - GET `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/metadata`
+
+- Deprecated route `getForecastMetadata`
+    - Starting from HDP 4.2.8
+    - Superseded by `getForecastIdMetadata`
+
 ### 7.0.2
 - Adding Route `getWorkspaces`
     - Available since HDP 4.2.6


### PR DESCRIPTION
### 7.0.3

- Adding Route `getForecastIdMetadata`
    - Available since HDP 4.2.8
    - GET `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/metadata`

- Deprecated route `getForecastMetadata`
    - Starting from HDP 4.2.8
    - Superseded by `getForecastIdMetadata`

### Build
https://eu-central-1.console.aws.amazon.com/codesuite/codebuild/projects/hyperapi_build/build/hyperapi_build%3A88fa5df4-0b43-4d24-9978-e87bc7129654/log?region=eu-central-1