### PR TITLE
[7.0.3][7.0.6.nitro]: merge Nitro 2 5 in master

### DIFF
--- a/HyperAPI/hdp_api/routes/nitro.py
+++ b/HyperAPI/hdp_api/routes/nitro.py
@@ -202,12 +202,24 @@ class Nitro(Resource):
     class _getForecastMetadata(Route):
         name = "getForecastMetadata"
         available_since = '4.2.3'
+        removed_since = '4.2.9'
         httpMethod = Route.GET
         path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/metadata"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'dataset_ID': Route.VALIDATOR_OBJECTID
         }
+
+    class _getForecastIdMetadata(Route):
+        name = "getForecastIdMetadata"
+        available_since = '4.2.9'
+        httpMethod = Route.GET
+        path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/metadata"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
+            'forecast_ID': Route.VALIDATOR_OBJECTID
+        }        
 
     class _getForecastTunesModalities(Route):
         name = "getForecastTunesModalities"

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,16 @@
 ### 7.0.4
 - Adding Perceptron Model
 
+### 7.0.3
+
+- Adding Route `getForecastIdMetadata`
+    - Available since HDP 4.2.9
+    - GET `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/metadata`
+
+- Deprecated route `getForecastMetadata`
+    - Starting from HDP 4.2.9
+    - Superseded by `getForecastIdMetadata`
+    
 ### 7.0.2
 - Adding Route `getWorkspaces`
     - Available since HDP 4.2.6


### PR DESCRIPTION
put the code from branch Nitro 2.5 to master (https://github.com/HyperCube/HyperAPI/pull/113)
No change of version but a temporary version : 7.0.6.nitro

### 7.0.3

- Adding Route `getForecastIdMetadata`
    - Available since HDP 4.2.9
    - GET `/nitro/projects/{project_ID}/datasets/{dataset_ID}/forecasts/{forecast_ID}/metadata`

- Deprecated route `getForecastMetadata`
    - Starting from HDP 4.2.9
    - Superseded by `getForecastIdMetadata`