### PR TITLE
[Nitro 2.6] add getPosRecurrence and updatePosRecurrence api

### DIFF
--- a/HyperAPI/hdp_api/routes/nitro.py
+++ b/HyperAPI/hdp_api/routes/nitro.py
@@ -221,18 +221,18 @@ class Nitro(Resource):
         }
 
     class _getPosRecurrence(Route):
-        name = "getPosRecurrence"
+        name = "getPosRecurrences"
         httpMethod = Route.POST
-        available_since = "4.4"
-        path = "/nitro/projects/{project_ID}/posRecurrence"
+        available_since = "4.2.10"
+        path = "/nitro/projects/{project_ID}/posRecurrences"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID
         }
     class _updatePosRecurrence(Route):
         name = "updatePosRecurrence"
         httpMethod = Route.POST
-        available_since = "4.4"
-        path = "/nitro/projects/{project_ID}/posRecurrence/{pos_ID}"
+        available_since = "4.2.10"
+        path = "/nitro/projects/{project_ID}/posRecurrences/{pos_ID}"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
             'pos_ID': Route.VALIDATOR_OBJECTID

--- a/HyperAPI/hdp_api/routes/nitro.py
+++ b/HyperAPI/hdp_api/routes/nitro.py
@@ -219,3 +219,21 @@ class Nitro(Resource):
             'dataset_ID': Route.VALIDATOR_OBJECTID,
             'forecast_ID': Route.VALIDATOR_OBJECTID
         }
+
+    class _getPosRecurrence(Route):
+        name = "getPosRecurrence"
+        httpMethod = Route.POST
+        available_since = "4.4"
+        path = "/nitro/projects/{project_ID}/posRecurrence"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID
+        }
+    class _updatePosRecurrence(Route):
+        name = "updatePosRecurrence"
+        httpMethod = Route.POST
+        available_since = "4.4"
+        path = "/nitro/projects/{project_ID}/posRecurrence/{pos_ID}"
+        _path_keys = {
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'pos_ID': Route.VALIDATOR_OBJECTID
+        }

--- a/HyperAPI/hdp_api/routes/nitro.py
+++ b/HyperAPI/hdp_api/routes/nitro.py
@@ -220,20 +220,23 @@ class Nitro(Resource):
             'forecast_ID': Route.VALIDATOR_OBJECTID
         }
 
-    class _getPosRecurrence(Route):
+    class _getPosRecurrences(Route):
         name = "getPosRecurrences"
         httpMethod = Route.POST
         available_since = "4.2.10"
-        path = "/nitro/projects/{project_ID}/posRecurrences"
+        path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/recurrences"
         _path_keys = {
-            'project_ID': Route.VALIDATOR_OBJECTID
+            'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID
         }
+
     class _updatePosRecurrence(Route):
         name = "updatePosRecurrence"
         httpMethod = Route.POST
         available_since = "4.2.10"
-        path = "/nitro/projects/{project_ID}/posRecurrences/{pos_ID}"
+        path = "/nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/{pos_ID}/recurrences"
         _path_keys = {
             'project_ID': Route.VALIDATOR_OBJECTID,
+            'dataset_ID': Route.VALIDATOR_OBJECTID,
             'pos_ID': Route.VALIDATOR_OBJECTID
         }

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ## Version 7
 
+### 7.0.9
+- Adding Route `getPosRecurrences`
+    - Available since HDP 4.2.10
+    - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/recurrences`
+
+- Adding Route `updatePosRecurrence`
+    - Available since HDP 4.2.10
+    - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/{pos_ID}/recurrences`
+
 ### 7.0.8
 - Using string delimiters when creating datasets in mongo
 


### PR DESCRIPTION
7.0.9
Adding Route getPosRecurrences and updatePosRecurrence

- Adding Route `getPosRecurrences`
    - Available since HDP 4.2.10
    - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/recurrences`

- Adding Route `updatePosRecurrence`
    - Available since HDP 4.2.10
    - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/{pos_ID}/recurrences`