### PR TITLE
7.0.10 fix version Adding Route getPosRecurrences and updatePosRecurrence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Version 7
 
-### 7.0.9
+### 7.0.10
 - Adding Route `getPosRecurrences`
     - Available since HDP 4.2.10
     - POST `/nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/recurrences`


### PR DESCRIPTION
7.0.10
Adding Route getPosRecurrences and updatePosRecurrence

Adding Route getPosRecurrences

Available since HDP 4.2.10
POST /nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/recurrences
Adding Route updatePosRecurrence

Available since HDP 4.2.10
POST /nitro/projects/{project_ID}/datasets/{dataset_ID}/pos/{pos_ID}/recurrences